### PR TITLE
Start tagging operators

### DIFF
--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         os: [macOS]

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ develop: mathics_scanner/data/characters.json
 
 #: Build distribution
 dist: admin-tools/make-dist.sh
-	$(ShelL) admin-tools/make-dist.sh
+	$(SHELL) admin-tools/make-dist.sh
 
 #: Install mathics
 install: build

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ To regenerate scanner tables run:
 
 ::
 
-   $ python -m mathics_scanner.generate.build_tables
+   $ mathics-generate-json-table
 
 Implementation
 --------------

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -3861,7 +3861,8 @@ GraySquare:
   unicode-equivalent-name: BLACK SQUARE
   wl-unicode: "\uF752"
 GreaterEqual:
-  esc-alias: '>='
+  ascii: ">="
+  esc-alias: ">="
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: GreaterEqual
@@ -4412,7 +4413,8 @@ Less:
   wl-unicode: <
   wl-unicode-name: LESS-THAN SIGN
 LessEqual:
-  esc-alias: <=
+  ascii: "<="
+  esc-alias: "<="
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: LessEqual
@@ -5462,12 +5464,15 @@ RawEscape:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\e"
+# Note: RawGreater WL's name for Mathics Greater or ASCII ">"
 RawGreater:
-  has-unicode-inverse: false
+  ascii: ">"
+  has-unicode-inverse: true
   is-letter-like: false
-  unicode-equivalent: '>'
+  operator-name: Greater
+  unicode-equivalent: "\u003e"
   unicode-equivalent-name: GREATER-THAN SIGN
-  wl-unicode: '>'
+  wl-unicode: "\u003e"
   wl-unicode-name: GREATER-THAN SIGN
 RawLeftBrace:
   has-unicode-inverse: false
@@ -6417,6 +6422,7 @@ SelectionPlaceholder:
   is-letter-like: true
   wl-unicode: "\uF527"
 Set:
+  ascii: "="
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Set
@@ -6424,6 +6430,11 @@ Set:
   unicode-equivalent-name: EQUALS SIGN
   wl-unicode: "="
   wl-unicode-name: EQUALS SIGN
+SetDelayed:
+  ascii: ":="
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: SetDelayed
 Sharp:
   has-unicode-inverse: false
   is-letter-like: true
@@ -6914,6 +6925,16 @@ UndirectedEdge:
   unicode-equivalent: "\u2194"
   unicode-equivalent-name: LEFT RIGHT ARROW
   wl-unicode: "\uF3D4"
+UnSameQ:
+  ascii: "=!="
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: UnSameQ
+UnSet:
+  ascii: "=."
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: UnSet
 Union:
   esc-alias: un
   has-unicode-inverse: false

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1,5 +1,8 @@
 # Information about named characters, indexed by their fully qualified names.
 #
+#   ascii: If present, the ASCII equivalent. In some cases this may be more
+#          than one character. For example "->" or "===".
+#
 #   esc-alias: The ESC sequence alias of the named character, if it exists.
 #
 #   has-unicode-inverse: Whether or not this named character has a unicode
@@ -7,17 +10,22 @@
 #
 #   is-letter-like: Whether or not this named-character is "letter-like".
 #
-#   operator-name: If present, this symbol is an operator with the given name.
+#   operator-name: If present, this symbol is a Mathics operator with
+#                  whose class name is the given name. For example Divide.
 #
 #   unicode-equivalent: A unicode equivalent for the named-character, if it
 #                       exists.
 #
 #   unicode-equivalent-name: The name of the unicode equivalent, if it exists.
+#                            The Python module unicodedata contains a list of
+#                            unicode names that we check against. So if the character
+#                            or unicode symbol is not in that, don't use it here.
 #
 #   wl-unicode: The unicode code point used by Mathics internally to represent
 #               the named character.
 #
-#   wl-unicode-name: The name of the character corresponding to `wl-unicode`.
+#   wl-unicode-name: The name of the character corresponding to `wl-unicode`, if it exists.
+#                    It will mentioned in Wolfram Language docs if it exists.
 
 AAcute:
   esc-alias: a'
@@ -1439,12 +1447,13 @@ Divides:
   wl-unicode: "\u2223"
   wl-unicode-name: DIVIDES
 Dot:
+  ascii: "."
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Dot
-  unicode-equivalent: .
+  unicode-equivalent: "."
   unicode-equivalent-name: FULL STOP
-  wl-unicode: .
+  wl-unicode: "."
   wl-unicode-name: FULL STOP
 DotEqual:
   esc-alias: .=
@@ -2341,9 +2350,11 @@ Epsilon:
   wl-unicode: "\u03F5"
   wl-unicode-name: GREEK LUNATE EPSILON SYMBOL
 Equal:
-  esc-alias: ==
+  ascii: "=="
+  esc-alias: "=="
   has-unicode-inverse: true
   is-letter-like: false
+  operator-name: Equal
   unicode-equivalent: "\u2A75"
   unicode-equivalent-name: TWO CONSECUTIVE EQUALS SIGNS
   wl-unicode: "\uF431"
@@ -2419,12 +2430,13 @@ ExponentialE:
   unicode-equivalent-name: DOUBLE-STRUCK ITALIC SMALL E
   wl-unicode: "\uF74D"
 Factorial:
+  ascii: "!"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Factorial
-  unicode-equivalent: '!'
+  unicode-equivalent: "!"
   unicode-equivalent-name: EXCLAMATION MARK
-  wl-unicode: '!'
+  wl-unicode: "!"
   wl-unicode-name: EXCLAMATION MARK
 FiLigature:
   has-unicode-inverse: false
@@ -4038,6 +4050,12 @@ Implies:
   unicode-equivalent: "\u27F9"
   unicode-equivalent-name: LONG RIGHTWARDS DOUBLE ARROW
   wl-unicode: "\uF523"
+IndentingNewLine:
+  esc-alias: nl
+  has-unicode-inverse: false
+  is-letter-like: false
+  unicode-equivalent: "\u000A"
+  wl-unicode: "\uF3A3"
 Infinity:
   esc-alias: inf
   has-unicode-inverse: false
@@ -4563,12 +4581,13 @@ Micro:
   wl-unicode: "\xB5"
   wl-unicode-name: MICRO SIGN
 Minus:
+  ascii: "-"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Minus
-  unicode-equivalent: '-'
+  unicode-equivalent: "-"
   unicode-equivalent-name: HYPHEN-MINUS
-  wl-unicode: '-'
+  wl-unicode: "-"
   wl-unicode-name: HYPHEN-MINUS
 MinusPlus:
   esc-alias: -+
@@ -4663,6 +4682,11 @@ NeutralSmiley:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF722"
+NewLine:
+  has-unicode-inverse: true
+  is-letter-like: false
+  unicode-equivalent: "\u000A"
+  wl-unicode: "\u000A"
 NoBreak:
   esc-alias: nb
   has-unicode-inverse: false
@@ -4675,6 +4699,11 @@ NonBreakingSpace:
   is-letter-like: false
   wl-unicode: "\_"
   wl-unicode-name: NO-BREAK SPACE
+NonCommutativeMultiply:
+  ascii: "**"
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: NonCommutativeMultiply
 Nor:
   esc-alias: nor
   has-unicode-inverse: false
@@ -4721,9 +4750,11 @@ NotElement:
   wl-unicode: "\u2209"
   wl-unicode-name: NOT AN ELEMENT OF
 NotEqual:
+  ascii: "!="
   esc-alias: '!='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotEqual
   unicode-equivalent: "\u2260"
   unicode-equivalent-name: NOT EQUAL TO
   wl-unicode: "\u2260"
@@ -5257,12 +5288,13 @@ Placeholder:
   unicode-equivalent-name: APL FUNCTIONAL SYMBOL QUAD
   wl-unicode: "\uF528"
 Plus:
+  ascii: "+"
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Plus
-  unicode-equivalent: +
+  unicode-equivalent: "+"
   unicode-equivalent-name: PLUS SIGN
-  wl-unicode: +
+  wl-unicode: "+"
   wl-unicode-name: PLUS SIGN
 PlusMinus:
   esc-alias: +-
@@ -5280,12 +5312,13 @@ Pluto:
   wl-unicode: "\u2647"
   wl-unicode-name: PLUTO
 Power:
+  ascii: "^"
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Power
-  unicode-equivalent: ^
+  unicode-equivalent: "^"
   unicode-equivalent-name: CIRCUMFLEX ACCENT
-  wl-unicode: ^
+  wl-unicode: "^"
   wl-unicode-name: CIRCUMFLEX ACCENT
 Precedes:
   has-unicode-inverse: false
@@ -5485,6 +5518,11 @@ RawQuote:
   unicode-equivalent-name: APOSTROPHE
   wl-unicode: ''''
   wl-unicode-name: APOSTROPHE
+RawReturn:
+  has-unicode-inverse: true
+  is-letter-like: false
+  unicode-equivalent: "\u000D"
+  wl-unicode: "\u000D"
 RawRightBrace:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5539,9 +5577,7 @@ RawTab:
   has-unicode-inverse: false
   is-letter-like: false
   unicode-equivalent: "\t"
-  unicode-equivalent-name: HORIZONTAL TABULATION
   wl-unicode: "\t"
-  wl-unicode-name: HORIZONTAL TABULATION
 RawTilde:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5903,6 +5939,11 @@ SagittariusSign:
   unicode-equivalent-name: SAGITTARIUS
   wl-unicode: "\u2650"
   wl-unicode-name: SAGITTARIUS
+SameQ:
+  ascii: "==="
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: SameQ
 Sampi:
   esc-alias: sa
   has-unicode-inverse: true
@@ -6764,9 +6805,11 @@ TildeTilde:
   wl-unicode: "\u2248"
   wl-unicode-name: ALMOST EQUAL TO
 Times:
+  ascii: '*'
   esc-alias: '*'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Times
   unicode-equivalent: "\xD7"
   unicode-equivalent-name: MULTIPLICATION SIGN
   wl-unicode: "\xD7"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1,15 +1,24 @@
-# Information about named characters, indexed by their fully qualified names
+# Information about named characters, indexed by their fully qualified names.
 #
-# esc-alias: The ESC sequence aliais of the named character, if it exists
-# has-unicode-inverse: Whether or not this named character has a unicode
-#                      equivalent to should replaced by it
-# is-letter-like: Whether or not this named-character is "letter-like"
-# unicode-equivalent: A unicode equivalent for the named-character, if it
-#                     exists
-# unicode-equivalent-name: The name of the unicode equivalent, if it exists
-# wl-unicode: The unicode code point used by Mathics internally to represent
-#             the named character
-# wl-unicode-name: The name of the character corresponding to `wl-unicode`
+#   esc-alias: The ESC sequence alias of the named character, if it exists.
+#
+#   has-unicode-inverse: Whether or not this named character has a unicode
+#                        equivalent to should replaced by it.
+#
+#   is-letter-like: Whether or not this named-character is "letter-like".
+#
+#   operator-name: If present, this symbol is an operator with the given name.
+#
+#   unicode-equivalent: A unicode equivalent for the named-character, if it
+#                       exists.
+#
+#   unicode-equivalent-name: The name of the unicode equivalent, if it exists.
+#
+#   wl-unicode: The unicode code point used by Mathics internally to represent
+#               the named character.
+#
+#   wl-unicode-name: The name of the character corresponding to `wl-unicode`.
+
 AAcute:
   esc-alias: a'
   has-unicode-inverse: false
@@ -1097,7 +1106,7 @@ Conditioned:
   wl-unicode: "\uF3D3"
 Congruent:
   esc-alias: ===
-  has-unicode-inverse: false
+  has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2261"
   unicode-equivalent-name: IDENTICAL TO
@@ -1414,8 +1423,9 @@ Distributed:
   wl-unicode: "\uF3D2"
 Divide:
   esc-alias: div
-  has-unicode-inverse: false
+  has-unicode-inverse: true
   is-letter-like: false
+  operator-name: Divide
   unicode-equivalent: "\xF7"
   unicode-equivalent-name: DIVISION SIGN
   wl-unicode: "\xF7"
@@ -1428,6 +1438,14 @@ Divides:
   unicode-equivalent-name: DIVIDES
   wl-unicode: "\u2223"
   wl-unicode-name: DIVIDES
+Dot:
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: Dot
+  unicode-equivalent: .
+  unicode-equivalent-name: FULL STOP
+  wl-unicode: .
+  wl-unicode-name: FULL STOP
 DotEqual:
   esc-alias: .=
   has-unicode-inverse: false
@@ -2400,6 +2418,14 @@ ExponentialE:
   unicode-equivalent: "\u2147"
   unicode-equivalent-name: DOUBLE-STRUCK ITALIC SMALL E
   wl-unicode: "\uF74D"
+Factorial:
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: Factorial
+  unicode-equivalent: '!'
+  unicode-equivalent-name: EXCLAMATION MARK
+  wl-unicode: '!'
+  wl-unicode-name: EXCLAMATION MARK
 FiLigature:
   has-unicode-inverse: false
   is-letter-like: false
@@ -3824,8 +3850,9 @@ GraySquare:
   wl-unicode: "\uF752"
 GreaterEqual:
   esc-alias: '>='
-  has-unicode-inverse: false
+  has-unicode-inverse: true
   is-letter-like: false
+  operator-name: GreaterEqual
   unicode-equivalent: "\u2265"
   unicode-equivalent-name: GREATER-THAN OR EQUAL TO
   wl-unicode: "\u2265"
@@ -4358,10 +4385,19 @@ LeoSign:
   unicode-equivalent-name: LEO
   wl-unicode: "\u264C"
   wl-unicode-name: LEO
+Less:
+  has-unicode-inverse: true
+  is-letter-like: false
+  operator-name: Less
+  unicode-equivalent: <
+  unicode-equivalent-name: LESS-THAN SIGN
+  wl-unicode: <
+  wl-unicode-name: LESS-THAN SIGN
 LessEqual:
   esc-alias: <=
-  has-unicode-inverse: false
+  has-unicode-inverse: true
   is-letter-like: false
+  operator-name: LessEqual
   unicode-equivalent: "\u2264"
   unicode-equivalent-name: LESS-THAN OR EQUAL TO
   wl-unicode: "\u2264"
@@ -4526,6 +4562,14 @@ Micro:
   unicode-equivalent-name: MICRO SIGN
   wl-unicode: "\xB5"
   wl-unicode-name: MICRO SIGN
+Minus:
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: Minus
+  unicode-equivalent: '-'
+  unicode-equivalent-name: HYPHEN-MINUS
+  wl-unicode: '-'
+  wl-unicode-name: HYPHEN-MINUS
 MinusPlus:
   esc-alias: -+
   has-unicode-inverse: false
@@ -5212,6 +5256,14 @@ Placeholder:
   unicode-equivalent: "\u2395"
   unicode-equivalent-name: APL FUNCTIONAL SYMBOL QUAD
   wl-unicode: "\uF528"
+Plus:
+  has-unicode-inverse: true
+  is-letter-like: false
+  operator-name: Plus
+  unicode-equivalent: +
+  unicode-equivalent-name: PLUS SIGN
+  wl-unicode: +
+  wl-unicode-name: PLUS SIGN
 PlusMinus:
   esc-alias: +-
   has-unicode-inverse: false
@@ -5227,6 +5279,14 @@ Pluto:
   unicode-equivalent-name: PLUTO
   wl-unicode: "\u2647"
   wl-unicode-name: PLUTO
+Power:
+  has-unicode-inverse: true
+  is-letter-like: false
+  operator-name: Power
+  unicode-equivalent: ^
+  unicode-equivalent-name: CIRCUMFLEX ACCENT
+  wl-unicode: ^
+  wl-unicode-name: CIRCUMFLEX ACCENT
 Precedes:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5351,13 +5411,6 @@ RawComma:
   unicode-equivalent-name: COMMA
   wl-unicode: ','
   wl-unicode-name: COMMA
-RawDash:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: '-'
-  unicode-equivalent-name: HYPHEN-MINUS
-  wl-unicode: '-'
-  wl-unicode-name: HYPHEN-MINUS
 RawDollar:
   has-unicode-inverse: false
   is-letter-like: true
@@ -5365,13 +5418,6 @@ RawDollar:
   unicode-equivalent-name: DOLLAR SIGN
   wl-unicode: $
   wl-unicode-name: DOLLAR SIGN
-RawDot:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: .
-  unicode-equivalent-name: FULL STOP
-  wl-unicode: .
-  wl-unicode-name: FULL STOP
 RawDoubleQuote:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5379,24 +5425,10 @@ RawDoubleQuote:
   unicode-equivalent-name: QUOTATION MARK
   wl-unicode: '"'
   wl-unicode-name: QUOTATION MARK
-RawEqual:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: '='
-  unicode-equivalent-name: EQUALS SIGN
-  wl-unicode: '='
-  wl-unicode-name: EQUALS SIGN
 RawEscape:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\e"
-RawExclamation:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: '!'
-  unicode-equivalent-name: EXCLAMATION MARK
-  wl-unicode: '!'
-  wl-unicode-name: EXCLAMATION MARK
 RawGreater:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5425,13 +5457,6 @@ RawLeftParenthesis:
   unicode-equivalent-name: LEFT PARENTHESIS
   wl-unicode: (
   wl-unicode-name: LEFT PARENTHESIS
-RawLess:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: <
-  unicode-equivalent-name: LESS-THAN SIGN
-  wl-unicode: <
-  wl-unicode-name: LESS-THAN SIGN
 RawNumberSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5446,13 +5471,6 @@ RawPercent:
   unicode-equivalent-name: PERCENT SIGN
   wl-unicode: '%'
   wl-unicode-name: PERCENT SIGN
-RawPlus:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: +
-  unicode-equivalent-name: PLUS SIGN
-  wl-unicode: +
-  wl-unicode-name: PLUS SIGN
 RawQuestion:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5496,8 +5514,9 @@ RawSemicolon:
   wl-unicode: ;
   wl-unicode-name: SEMICOLON
 RawSlash:
-  has-unicode-inverse: false
+  has-unicode-inverse: true
   is-letter-like: false
+  operator-name: Divide
   unicode-equivalent: /
   unicode-equivalent-name: SOLIDUS
   wl-unicode: /
@@ -5544,13 +5563,6 @@ RawVerticalBar:
   unicode-equivalent-name: VERTICAL LINE
   wl-unicode: '|'
   wl-unicode-name: VERTICAL LINE
-RawWedge:
-  has-unicode-inverse: false
-  is-letter-like: false
-  unicode-equivalent: ^
-  unicode-equivalent-name: CIRCUMFLEX ACCENT
-  wl-unicode: ^
-  wl-unicode-name: CIRCUMFLEX ACCENT
 RegisteredTrademark:
   esc-alias: rtm
   has-unicode-inverse: false
@@ -5848,12 +5860,14 @@ Rule:
   esc-alias: ->
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Rule
   unicode-equivalent: "\u2192"
   unicode-equivalent-name: RIGHTWARDS ARROW
   wl-unicode: "\uF522"
 RuleDelayed:
   esc-alias: :>
   has-unicode-inverse: true
+  operator-name: RuleDelayed
   is-letter-like: false
   unicode-equivalent: "\u29F4"
   unicode-equivalent-name: RULE-DELAYED
@@ -6361,6 +6375,14 @@ SelectionPlaceholder:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF527"
+Set:
+  has-unicode-inverse: true
+  is-letter-like: false
+  operator-name: Set
+  unicode-equivalent: "="
+  unicode-equivalent-name: EQUALS SIGN
+  wl-unicode: "="
+  wl-unicode-name: EQUALS SIGN
 Sharp:
   has-unicode-inverse: false
   is-letter-like: true

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -22,7 +22,13 @@ def read(*rnames):
 
 
 # stores __version__ in the current namespace
-exec(compile(open(Path(get_srcdir()) / ".." / "version.py").read(), "mathics_scanner/version.py", "exec"))
+exec(
+    compile(
+        open(Path(get_srcdir()) / ".." / "version.py").read(),
+        "mathics_scanner/version.py",
+        "exec",
+    )
+)
 
 
 def re_from_keys(d: dict) -> str:
@@ -89,6 +95,7 @@ def compile_tables(data: dict) -> dict:
     wl_to_ascii_dict = {
         v["wl-unicode"]: get_plain_text(k, v, use_unicode=False)
         for k, v in data.items()
+        if "wl-unicode" in v
     }
     wl_to_ascii_dict = {k: v for k, v in wl_to_ascii_dict.items() if k != v}
     wl_to_ascii_re = re_from_keys(wl_to_ascii_dict)
@@ -96,7 +103,9 @@ def compile_tables(data: dict) -> dict:
     # Conversion from wl to unicode
     # We filter the dictionary after it's first created to redundant entries
     wl_to_unicode_dict = {
-        v["wl-unicode"]: get_plain_text(k, v, use_unicode=True) for k, v in data.items()
+        v["wl-unicode"]: get_plain_text(k, v, use_unicode=True)
+        for k, v in data.items()
+        if "wl-unicode" in v
     }
     wl_to_unicode_dict = {k: v for k, v in wl_to_unicode_dict.items() if k != v}
     wl_to_unicode_re = re_from_keys(wl_to_unicode_dict)
@@ -115,7 +124,9 @@ def compile_tables(data: dict) -> dict:
     letterlikes = "".join(v["wl-unicode"] for v in data.values() if v["is-letter-like"])
 
     # All supported named characters
-    named_characters = {k: v["wl-unicode"] for k, v in data.items()}
+    named_characters = {
+        k: v["wl-unicode"] for k, v in data.items() if "wl-unicode" in v
+    }
 
     # ESC sequence aliases
     aliased_characters = {
@@ -126,7 +137,7 @@ def compile_tables(data: dict) -> dict:
     operator_to_unicode = {
         v["operator-name"]: v["unicode-equivalent"]
         for k, v in data.items()
-        if "operator-name" in v
+        if "operator-name" in v and "unicode-equivalent" in v
     }
 
     return {
@@ -161,11 +172,16 @@ ALL_FIELDS = [
 
 @click.command()
 @click.version_option(version=__version__)
-@click.option("--field", "-f", multiple=True, required=False,
-              help="Select which fields to include in JSON.",
-              show_default=True,
-              type=click.Choice(ALL_FIELDS),
-              default=ALL_FIELDS)
+@click.option(
+    "--field",
+    "-f",
+    multiple=True,
+    required=False,
+    help="Select which fields to include in JSON.",
+    show_default=True,
+    type=click.Choice(ALL_FIELDS),
+    default=ALL_FIELDS,
+)
 @click.option(
     "--output",
     "-o",

--- a/mathics_scanner/load.py
+++ b/mathics_scanner/load.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from mathics_scanner.generate.build_tables import DEFAULT_DATA_DIR
+import yaml
+import json
+
+def load_mathics_character_yaml():
+    with open(DEFAULT_DATA_DIR / "named-characters.yml", "r") as yaml_file:
+        yaml_data = yaml.load(yaml_file, Loader=yaml.FullLoader)
+    return yaml_data
+
+def load_mathics_character_json():
+    with open(DEFAULT_DATA_DIR / "characters.json", "r") as json_file:
+        json_data = json.load(json_file)
+    return json_data

--- a/mathics_scanner/version.py
+++ b/mathics_scanner/version.py
@@ -4,4 +4,4 @@
 # This file is suitable for sourcing inside POSIX shell as
 # well as importing into Python. That's why there is no
 # space around "=" below.
-__version__="1.0.0"  # noqa
+__version__="1.0.1.dev0"  # noqa

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 PyYAML
+click

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ if sys.version_info < (3, 6):
     print("mathics-scanner does not support Python %d.%d" % sys.version_info[:2])
     sys.exit(-1)
 
+
 def get_srcdir():
     filename = osp.normcase(osp.dirname(osp.abspath(__file__)))
     return osp.realpath(filename)
@@ -44,10 +45,13 @@ def get_srcdir():
 def read(*rnames):
     return open(osp.join(get_srcdir(), *rnames)).read()
 
-subprocess.run(["make", "mathics_scanner/data/characters.json"])
 
 # stores __version__ in the current namespace
-exec(compile(open("mathics_scanner/version.py").read(), "mathics_scanner/version.py", "exec"))
+exec(
+    compile(
+        open("mathics_scanner/version.py").read(), "mathics_scanner/version.py", "exec"
+    )
+)
 
 # Get/set __version__ and long_description from files
 long_description = read("README.rst") + "\n"
@@ -55,13 +59,11 @@ long_description = read("README.rst") + "\n"
 
 is_PyPy = platform.python_implementation() == "PyPy"
 
-INSTALL_REQUIRES = []
-DEPENDENCY_LINKS = []
-
 # General Requirements
-INSTALL_REQUIRES += [
-    "chardet", # Used in mathics_scanner.feed
-    "ujson", # Used in mathics_scanner.characters
+INSTALL_REQUIRES = [
+    "chardet",  # Used in mathics_scanner.feed
+    "ujson",  # Used in mathics_scanner.characters
+    "click",  # Usin in CLI: mathics-generate-json-table
 ]
 
 
@@ -78,7 +80,11 @@ setup(
         "mathics_scanner.generate",
     ],
     install_requires=INSTALL_REQUIRES,
-    dependency_links=DEPENDENCY_LINKS,
+    entry_points={
+        "console_scripts": [
+            "mathics-generate-json-table=mathics_scanner.generate.build_tables:main"
+        ]
+    },
     package_data={
         "mathics_scanner": [
             "data/*.csv",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ subprocess.run(["make", "mathics_scanner/data/characters.json"])
 # stores __version__ in the current namespace
 exec(compile(open("mathics_scanner/version.py").read(), "mathics_scanner/version.py", "exec"))
 
-# Get/set VERSION and long_description from files
+# Get/set __version__ and long_description from files
 long_description = read("README.rst") + "\n"
 
 

--- a/test/test_general_yaml_sanity.py
+++ b/test/test_general_yaml_sanity.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from .util import yaml_data
+from mathics_scanner.load import load_mathics_character_yaml
 import unicodedata
 
+yaml_data = load_mathics_character_yaml()
 
 def check_attr_is_invertible(attr: str):
     for v in yaml_data.values():

--- a/test/test_general_yaml_sanity.py
+++ b/test/test_general_yaml_sanity.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from test.util import yaml_data
+from .util import yaml_data
 import unicodedata
+
 
 def check_attr_is_invertible(attr: str):
     for v in yaml_data.values():
         if attr in v:
             attr_v = v[attr]
 
-            attr_vs = [c for c, v in yaml_data.items() 
-                       if v.get(attr) == attr_v ]
+            attr_vs = [c for c, v in yaml_data.items() if v.get(attr) == attr_v]
 
             assert (
                 len(attr_vs) == 1
@@ -21,11 +21,27 @@ def check_has_attr(attr: str):
         assert attr in v, f"{k} has no {attr} attribute"
 
 
-def check_wl_unicode_name():
+def test_yaml_field_names():
+    for k, v in yaml_data.items():
+
+        diff = set(v.keys()) - {
+            "esc-alias",
+            "has-unicode-inverse",
+            "is-letter-like",
+            "operator-name",
+            "unicode-equivalent",
+            "unicode-equivalent-name",
+            "wl-unicode",
+            "wl-unicode-name",
+        }
+        assert diff == set(), f"Item {k} has unknown fields {diff}"
+
+
+def test_wl_unicode_name():
     for k, v in yaml_data.items():
         wl = v["wl-unicode"]
 
-        # Hack to skip characters that are correct but that doesn't show up in 
+        # Hack to skip characters that are correct but that doesn't show up in
         # unicodedata.name
         if k == "RawTab" and v["wl-unicode-name"] == "HORIZONTAL TABULATION":
             continue
@@ -48,9 +64,9 @@ def check_wl_unicode_name():
         ), f"{k} has wl-unicode-name set to {real_name} but it should be {expected_name}"
 
 
-def check_unicode_name():
+def test_unicode_name():
     for k, v in yaml_data.items():
-        # Hack to skip characters that are correct but that doesn't show up in 
+        # Hack to skip characters that are correct but that doesn't show up in
         # unicodedata.name
         if k == "RawTab" and v["unicode-equivalent-name"] == "HORIZONTAL TABULATION":
             continue
@@ -61,12 +77,16 @@ def check_unicode_name():
             try:
                 expected_name = " + ".join(unicodedata.name(c) for c in uni)
             except ValueError:
-                raise ValueError(f"{k}'s unicode-equivalent doesn't have a unicode name (it's not valid unicode)")
+                raise ValueError(
+                    f"{k}'s unicode-equivalent doesn't have a unicode name (it's not valid unicode)"
+                )
 
             real_name = v.get("unicode-equivalent-name")
 
             if real_name is None:
-                raise ValueError("{k} has a unicode equivalent but doesn't have the unicode-equivalent-name field")
+                raise ValueError(
+                    "{k} has a unicode equivalent but doesn't have the unicode-equivalent-name field"
+                )
 
             assert (
                 real_name == expected_name
@@ -86,8 +106,3 @@ def test_general_yaml_sanity():
     # Check if attributes that should be invertible are in fact invertible
     check_attr_is_invertible("wl-unicode")
     check_attr_is_invertible("esc-alias")
-
-    # Check the consistency of the unicode names in the table
-    check_wl_unicode_name()
-    check_unicode_name()
-

--- a/test/test_has_unicode_inverse_sanity.py
+++ b/test/test_has_unicode_inverse_sanity.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from mathics_scanner.load import load_mathics_character_yaml, load_mathics_character_json
+from mathics_scanner.load import (
+    load_mathics_character_yaml,
+    load_mathics_character_json,
+)
 
 yaml_data = load_mathics_character_yaml()
 json_data = load_mathics_character_json()
+
 
 def test_has_unicode_inverse_sanity():
     inverses = set()
@@ -16,15 +20,16 @@ def test_has_unicode_inverse_sanity():
 
             uni = v["unicode-equivalent"]
 
-            assert (
-                uni not in inverses
-            ), f"unicode character {uni} has multiple inverses"
+            assert uni not in inverses, f"unicode character {uni} has multiple inverses"
 
             inverses.add(uni)
 
     unicode_to_wl_dict = json_data["unicode-to-wl-dict"]
 
     for uni, wl in unicode_to_wl_dict.items():
-        assert (
-            any(v["wl-unicode"] == wl and v.get("unicode-equivalent") == uni and v["has-unicode-inverse"] for v in yaml_data.values())
+        assert any(
+            v["wl-unicode"] == wl
+            and v.get("unicode-equivalent") == uni
+            and v["has-unicode-inverse"]
+            for v in yaml_data.values() if "wl-unicode" in v
         ), f"key {uni} is in unicode-to-wl-dict but there is not corresponding entry in the YAML table"

--- a/test/test_has_unicode_inverse_sanity.py
+++ b/test/test_has_unicode_inverse_sanity.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from test.util import yaml_data, json_data
+from mathics_scanner.load import load_mathics_character_yaml, load_mathics_character_json
+
+yaml_data = load_mathics_character_yaml()
+json_data = load_mathics_character_json()
 
 def test_has_unicode_inverse_sanity():
     inverses = set()
@@ -25,4 +28,3 @@ def test_has_unicode_inverse_sanity():
         assert (
             any(v["wl-unicode"] == wl and v.get("unicode-equivalent") == uni and v["has-unicode-inverse"] for v in yaml_data.values())
         ), f"key {uni} is in unicode-to-wl-dict but there is not corresponding entry in the YAML table"
-

--- a/test/test_letterlikes_sanity.py
+++ b/test/test_letterlikes_sanity.py
@@ -1,4 +1,9 @@
-from test.util import yaml_data, json_data
+# -*- coding: utf-8 -*-
+
+from mathics_scanner.load import load_mathics_character_yaml, load_mathics_character_json
+
+yaml_data = load_mathics_character_yaml()
+json_data = load_mathics_character_json()
 
 def test_letterlikes_sanity():
     letterlikes = json_data["letterlikes"]
@@ -9,4 +14,3 @@ def test_letterlikes_sanity():
     assert (
         yaml_llc == json_llc
     ), f"the YAML table has {yaml_llc} letter-like characters but the JSON files lists {json_llc} letterlike characters"
-

--- a/test/test_table_consistency.py
+++ b/test/test_table_consistency.py
@@ -14,7 +14,10 @@ def test_roundtrip():
 
     for k, v in yaml_data.items():
         if v["has-unicode-inverse"]:
-            wl = v["wl-unicode"]
+            try:
+                wl = v["wl-unicode"]
+            except:
+                import pdb; pdb.set_trace()
             assert (
                 unicode_to_wl(wl_to_unicode(wl)) == wl
             ), f"key {k} unicode {uni}, {wl_to_unicode(uni)}"
@@ -41,6 +44,6 @@ def test_counts():
         named_characters_set
     ), "Number of letter-likes should be less than the number of all named characters"
 
-    assert set(yaml_data.keys()) == set(
+    assert set(yaml_data.keys()) >= set(
         json_data["named-characters"].keys()
     ), "There should be a named character for each WL symbol"

--- a/test/test_table_consistency.py
+++ b/test/test_table_consistency.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+
 from mathics_scanner.characters import replace_wl_with_plain_text as wl_to_unicode
 from mathics_scanner.characters import replace_unicode_with_wl as unicode_to_wl
-from .util import yaml_data, json_data
 
+from mathics_scanner.load import load_mathics_character_yaml, load_mathics_character_json
+
+yaml_data = load_mathics_character_yaml()
+json_data = load_mathics_character_json()
 
 def test_roundtrip():
     wl_to_unicode_dict = json_data["wl-to-unicode-dict"]

--- a/test/test_table_consistency.py
+++ b/test/test_table_consistency.py
@@ -1,6 +1,6 @@
 from mathics_scanner.characters import replace_wl_with_plain_text as wl_to_unicode
 from mathics_scanner.characters import replace_unicode_with_wl as unicode_to_wl
-from test.util import yaml_data, json_data
+from .util import yaml_data, json_data
 
 
 def test_roundtrip():

--- a/test/test_wl_to_ascii.py
+++ b/test/test_wl_to_ascii.py
@@ -13,6 +13,8 @@ def is_ascii(s: str) -> bool:
 
 def test_wl_to_ascii():
     for k, v in yaml_data.items():
+        if "wl-unicode" not in v:
+            continue
         wl = v["wl-unicode"]
 
         ascii_c = wl_to_ascii(wl)

--- a/test/test_wl_to_ascii.py
+++ b/test/test_wl_to_ascii.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from mathics_scanner.characters import replace_wl_with_plain_text
-from test.util import yaml_data
+from mathics_scanner.load import load_mathics_character_yaml
+
+yaml_data = load_mathics_character_yaml()
 
 def wl_to_ascii(wl_input: str) -> str:
     return replace_wl_with_plain_text(wl_input, use_unicode=False)
@@ -25,4 +27,3 @@ def test_wl_to_ascii():
             assert (
                 uni == ascii_c
             ), f"{k}'s unicode equivalent could be used as it's ASCII equivalent but it isn't"
-

--- a/test/util.py
+++ b/test/util.py
@@ -1,9 +1,0 @@
-from mathics_scanner.generate.build_tables import DEFAULT_DATA_DIR
-import yaml
-import json
-
-with open(DEFAULT_DATA_DIR / "named-characters.yml", "r") as yaml_file:
-    yaml_data = yaml.load(yaml_file, Loader=yaml.FullLoader)
-
-with open(DEFAULT_DATA_DIR / "characters.json", "r") as json_file:
-    json_data = json.load(json_file)


### PR DESCRIPTION
Note: use WL name when there is no conflict for name of symbol.

A number of other small corrections:

- Mark some symbols which are invertable when they are. However
  this should be redone and invertability should be detected
  automatically.
- small correction in macos CI
- AUTHORS.txt reduced to those who worked in this, rather than Mathics
  in general
- in tests prefer top-level tests when that is possible (i.e. test is
  not parameterized)
- use relative import as "test" can be ambiguous and lead to namespace problems