### PR TITLE
Tables for pygments

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,33 @@
+name: Mathics (Windows)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows]
+        python-version: [3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install Mathics_Scanner
+      run: |
+        python setup.py install
+    - name: Test Mathics
+      run: |
+        pip install pytest
+        pip install -r requirements-dev.txt
+        python mathics_scanner/generate/build_tables.py
+        py.test test

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -2527,7 +2527,7 @@ Equivalent:
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Equivalent
-  unicode-equivalent: "\u21D4"
+  unicode-equivalent: "\u29E6"
   unicode-equivalent-name: LEFT RIGHT DOUBLE ARROW
   wl-unicode: "\u29E6"
   wl-unicode-name: GLEICH STARK
@@ -4077,6 +4077,7 @@ GreaterGreater:
 GreaterLess:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: GreaterLess
   unicode-equivalent: "\u2277"
   unicode-equivalent-name: GREATER-THAN OR LESS-THAN
   wl-unicode: "\u2277"
@@ -4410,6 +4411,7 @@ LeftArrowBar:
 LeftArrowRightArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftArrowRightArrow
   unicode-equivalent: "\u21C6"
   unicode-equivalent-name: LEFTWARDS ARROW OVER RIGHTWARDS ARROW
   wl-unicode: "\u21C6"
@@ -4619,6 +4621,7 @@ LeftVector:
 LeftVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftVectorBar
   unicode-equivalent: "\u2952"
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB UP TO BAR
   wl-unicode: "\u2952"
@@ -4976,8 +4979,9 @@ Not:
   esc-alias: '!'
   has-unicode-inverse: false
   is-letter-like: false
+  unicode-equivalent: "\u00AC"
   operator-name: Not
-  wl-unicode: "\xAC"
+  wl-unicode: "\00AC"
   wl-unicode-name: NOT SIGN
 NotCongruent:
   esc-alias: '!==='
@@ -5167,6 +5171,7 @@ NotLessTilde:
   esc-alias: '!<~'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLessTilde
   unicode-equivalent: "\u2274"
   unicode-equivalent-name: NEITHER LESS-THAN NOR EQUIVALENT TO
   wl-unicode: "\u2274"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1378,11 +1378,14 @@ Definition:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Definition
+# Using Degree as an operator messes up parsing.
+# mathics-pygments would like this to be an operator.
+# We adjust for that in that code
 Degree:
   esc-alias: deg
   has-unicode-inverse: false
   is-letter-like: false
-  operator-name: Degree
+  # operator-name: Degree
   unicode-equivalent: "\xB0"
   unicode-equivalent-name: DEGREE SIGN
   wl-unicode: "\xB0"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -9,7 +9,9 @@
 #                        equivalent that should replace other variants of it,
 #                        e.g. named character or ascii equivalent.
 #
-#   is-letter-like: Whether or not this named-character is "letter-like".
+#   is-letter-like: Whether or not this named-character is "letter-like", or
+#                   can be used as part of a symbol. For example \[alpha]
+#                   is letter-like. Therefore we can write: \[alpha]5 = "testing"
 #
 #   operator-name: If present, this symbol is a Mathics operator with
 #                  whose class name is the given name. For example Divide.
@@ -1379,12 +1381,12 @@ Definition:
   is-letter-like: false
   operator-name: Definition
 
- # Using Degree as an operator messes up parsing,
-# but mathics-pygments would like this to be an operator.
-# We adjust for that in the mathics-pygments code
+# Using \[Degree] as an operator messes up Mathics parsing,
+# But mathics-pygments would like this to be an operator.
+# We adjust for that in the mathics-pygments code.
 
-# Also, in order for theto be able to write:
-# \[Degree] == Degree,
+# Also, in order too be able to write:
+#   \[Degree] == Degree,
 # \Degree has to be letter-like.
 Degree:
   esc-alias: deg

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -138,11 +138,16 @@ Aleph:
   unicode-equivalent-name: ALEF SYMBOL
   wl-unicode: "\u2135"
   wl-unicode-name: ALEF SYMBOL
+
 # Note: the unicode for AliasDelimiter doesn't look like "-"
+# https://reference.wolfram.com/language/ref/character/AliasDelimiter.html
+# says this is a textual representation for the ASCI "esc" character with code 27
 AliasDelimiter:
   has-unicode-inverse: false
+  unicode-equivalent: "\u0027"
   is-letter-like: false
   wl-unicode: "\uF764"
+
 AliasIndicator:
   esc-alias: esc
   has-unicode-inverse: false
@@ -2528,7 +2533,7 @@ Equivalent:
   is-letter-like: false
   operator-name: Equivalent
   unicode-equivalent: "\u29E6"
-  unicode-equivalent-name: LEFT RIGHT DOUBLE ARROW
+  unicode-equivalent-name: GLEICH STARK
   wl-unicode: "\u29E6"
   wl-unicode-name: GLEICH STARK
 ErrorIndicator:

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -156,9 +156,11 @@ AltKey:
   is-letter-like: false
   wl-unicode: "\uF7D1"
 And:
+  ascii: '&&'
   esc-alias: '&&'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: And
   unicode-equivalent: "\u2227"
   unicode-equivalent-name: LOGICAL AND
   wl-unicode: "\u2227"
@@ -5927,9 +5929,11 @@ RightDoubleBracket:
   wl-unicode: "\u301B"
   wl-unicode-name: RIGHT WHITE SQUARE BRACKET
 RightDoubleBracketingBar:
+  ascii: "||"
   esc-alias: r||
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Or
   unicode-equivalent: "\u2016"
   unicode-equivalent-name: DOUBLE VERTICAL LINE
   wl-unicode: "\uF606"
@@ -7000,8 +7004,10 @@ Thorn:
   wl-unicode-name: LATIN SMALL LETTER THORN
 Tilde:
   esc-alias: '~'
+  ascii: "~"
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Tilde
   unicode-equivalent: "\u223C"
   unicode-equivalent-name: TILDE OPERATOR
   wl-unicode: "\u223C"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1153,6 +1153,7 @@ Colon:
   esc-alias: ':'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Colon
   unicode-equivalent: "\u2236"
   unicode-equivalent-name: RATIO
   wl-unicode: "\u2236"
@@ -1187,6 +1188,7 @@ Congruent:
   esc-alias: ===
   has-unicode-inverse: true
   is-letter-like: false
+  operator-name: Congruent
   unicode-equivalent: "\u2261"
   unicode-equivalent-name: IDENTICAL TO
   wl-unicode: "\u2261"
@@ -1233,6 +1235,7 @@ Coproduct:
   esc-alias: coprod
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Coproduct
   unicode-equivalent: "\u2210"
   unicode-equivalent-name: N-ARY COPRODUCT
   wl-unicode: "\u2210"
@@ -1263,6 +1266,7 @@ Cross:
 Cup:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Cup
   unicode-equivalent: "\u2323"
   unicode-equivalent-name: SMILE
   wl-unicode: "\u2323"
@@ -1270,6 +1274,7 @@ Cup:
 CupCap:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CupCap
   unicode-equivalent: "\u224D"
   unicode-equivalent-name: EQUIVALENT TO
   wl-unicode: "\u224D"
@@ -1614,6 +1619,7 @@ DoubleDot:
 DoubleDownArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleDownArrow
   unicode-equivalent: "\u21D3"
   unicode-equivalent-name: DOWNWARDS DOUBLE ARROW
   wl-unicode: "\u21D3"
@@ -1622,6 +1628,7 @@ DoubleLeftArrow:
   esc-alias: ' <='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleLeftArrow
   unicode-equivalent: "\u21D0"
   unicode-equivalent-name: LEFTWARDS DOUBLE ARROW
   wl-unicode: "\u21D0"
@@ -1630,6 +1637,7 @@ DoubleLeftRightArrow:
   esc-alias: <=>
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleLeftRightArrow
   unicode-equivalent: "\u21D4"
   unicode-equivalent-name: LEFT RIGHT DOUBLE ARROW
   wl-unicode: "\u21D4"
@@ -1637,6 +1645,7 @@ DoubleLeftRightArrow:
 DoubleLeftTee:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleLeftTee
   unicode-equivalent: "\u2AE4"
   unicode-equivalent-name: VERTICAL BAR DOUBLE LEFT TURNSTILE
   wl-unicode: "\u2AE4"
@@ -1645,6 +1654,7 @@ DoubleLongLeftArrow:
   esc-alias: <==
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleLongLeftArrow
   unicode-equivalent: "\u27F8"
   unicode-equivalent-name: LONG LEFTWARDS DOUBLE ARROW
   wl-unicode: "\u27F8"
@@ -1653,6 +1663,7 @@ DoubleLongLeftRightArrow:
   esc-alias: <==>
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleLongLeftRightArrow
   unicode-equivalent: "\u27FA"
   unicode-equivalent-name: LONG LEFT RIGHT DOUBLE ARROW
   wl-unicode: "\u27FA"
@@ -1661,6 +1672,7 @@ DoubleLongRightArrow:
   esc-alias: ==>
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleLongRightArrow
   unicode-equivalent: "\u27F9"
   unicode-equivalent-name: LONG RIGHTWARDS DOUBLE ARROW
   wl-unicode: "\u27F9"
@@ -1677,6 +1689,7 @@ DoubleRightArrow:
   esc-alias: ' =>'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleRightArrow
   unicode-equivalent: "\u21D2"
   unicode-equivalent-name: RIGHTWARDS DOUBLE ARROW
   wl-unicode: "\u21D2"
@@ -1686,6 +1699,7 @@ DoubleRightTee:
   is-letter-like: false
   unicode-equivalent: "\u22A8"
   unicode-equivalent-name: 'TRUE'
+  operator-name: DoubleRightTee
   wl-unicode: "\u22A8"
   wl-unicode-name: 'TRUE'
 DoubleStruckA:
@@ -2125,6 +2139,7 @@ DoubleStruckZero:
 DoubleUpArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleUpArrow
   unicode-equivalent: "\u21D1"
   unicode-equivalent-name: UPWARDS DOUBLE ARROW
   wl-unicode: "\u21D1"
@@ -2132,6 +2147,7 @@ DoubleUpArrow:
 DoubleUpDownArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleUpDownArrow
   unicode-equivalent: "\u21D5"
   unicode-equivalent-name: UP DOWN DOUBLE ARROW
   wl-unicode: "\u21D5"
@@ -2140,6 +2156,7 @@ DoubleVerticalBar:
   esc-alias: ' ||'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleVerticalBar
   unicode-equivalent: "\u2225"
   unicode-equivalent-name: PARALLEL TO
   wl-unicode: "\u2225"
@@ -2161,6 +2178,7 @@ DoubledPi:
 DownArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownArrow
   unicode-equivalent: "\u2193"
   unicode-equivalent-name: DOWNWARDS ARROW
   wl-unicode: "\u2193"
@@ -2168,6 +2186,7 @@ DownArrow:
 DownArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownArrowBar
   unicode-equivalent: "\u2913"
   unicode-equivalent-name: DOWNWARDS ARROW TO BAR
   wl-unicode: "\u2913"
@@ -2175,6 +2194,7 @@ DownArrowBar:
 DownArrowUpArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownArrowUpArrow
   unicode-equivalent: "\u21F5"
   unicode-equivalent-name: DOWNWARDS ARROW LEFTWARDS OF UPWARDS ARROW
   wl-unicode: "\u21F5"
@@ -2197,6 +2217,7 @@ DownExclamation:
 DownLeftRightVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownLeftRightVector
   unicode-equivalent: "\u2950"
   unicode-equivalent-name: LEFT BARB DOWN RIGHT BARB DOWN HARPOON
   wl-unicode: "\u2950"
@@ -2204,6 +2225,7 @@ DownLeftRightVector:
 DownLeftTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownLeftTeeVector
   unicode-equivalent: "\u295E"
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB DOWN FROM BAR
   wl-unicode: "\u295E"
@@ -2211,6 +2233,7 @@ DownLeftTeeVector:
 DownLeftVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownLeftVector
   unicode-equivalent: "\u21BD"
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB DOWNWARDS
   wl-unicode: "\u21BD"
@@ -2218,6 +2241,7 @@ DownLeftVector:
 DownLeftVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownLeftVectorBar
   unicode-equivalent: "\u2956"
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB DOWN TO BAR
   wl-unicode: "\u2956"
@@ -2225,6 +2249,7 @@ DownLeftVectorBar:
 DownPointer:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownPointer
   unicode-equivalent: "\u25BE"
   unicode-equivalent-name: BLACK DOWN-POINTING SMALL TRIANGLE
   wl-unicode: "\u25BE"
@@ -2240,6 +2265,7 @@ DownQuestion:
 DownRightTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownRightTeeVector
   unicode-equivalent: "\u295F"
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB DOWN FROM BAR
   wl-unicode: "\u295F"
@@ -2247,6 +2273,7 @@ DownRightTeeVector:
 DownRightVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownRightVector
   unicode-equivalent: "\u21C1"
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB DOWNWARDS
   wl-unicode: "\u21C1"
@@ -2254,6 +2281,7 @@ DownRightVector:
 DownRightVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownRightVectorBar
   unicode-equivalent: "\u2957"
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB DOWN TO BAR
   wl-unicode: "\u2957"
@@ -2262,6 +2290,7 @@ DownTee:
   esc-alias: dT
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownTee
   unicode-equivalent: "\u22A4"
   unicode-equivalent-name: DOWN TACK
   wl-unicode: "\u22A4"
@@ -2269,6 +2298,7 @@ DownTee:
 DownTeeArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DownTeeArrow
   unicode-equivalent: "\u21A7"
   unicode-equivalent-name: DOWNWARDS ARROW FROM BAR
   wl-unicode: "\u21A7"
@@ -2470,6 +2500,7 @@ EqualTilde:
   esc-alias: =~
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: EqualTilde
   unicode-equivalent: "\u2242"
   unicode-equivalent-name: MINUS TILDE
   wl-unicode: "\u2242"
@@ -2478,6 +2509,7 @@ Equilibrium:
   esc-alias: equi
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Equilibrium
   unicode-equivalent: "\u21CC"
   unicode-equivalent-name: RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON
   wl-unicode: "\u21CC"
@@ -2486,6 +2518,7 @@ Equivalent:
   esc-alias: equiv
   has-unicode-inverse: true
   is-letter-like: false
+  operator-name: Equivalent
   unicode-equivalent: "\u21D4"
   unicode-equivalent-name: LEFT RIGHT DOUBLE ARROW
   wl-unicode: "\u29E6"
@@ -2680,6 +2713,7 @@ ForAll:
   esc-alias: fa
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ForAll
   unicode-equivalent: "\u2200"
   unicode-equivalent-name: FOR ALL
   wl-unicode: "\u2200"
@@ -4011,6 +4045,7 @@ GreaterEqual:
 GreaterEqualLess:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: GreaterEqualLess
   unicode-equivalent: "\u22DB"
   unicode-equivalent-name: GREATER-THAN EQUAL TO OR LESS-THAN
   wl-unicode: "\u22DB"
@@ -4018,6 +4053,7 @@ GreaterEqualLess:
 GreaterFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: GreaterFullEqual
   unicode-equivalent: "\u2267"
   unicode-equivalent-name: GREATER-THAN OVER EQUAL TO
   wl-unicode: "\u2267"
@@ -4025,6 +4061,7 @@ GreaterFullEqual:
 GreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: GreaterGreater
   unicode-equivalent: "\u226B"
   unicode-equivalent-name: MUCH GREATER-THAN
   wl-unicode: "\u226B"
@@ -4039,6 +4076,7 @@ GreaterLess:
 GreaterSlantEqual:
   esc-alias: '>/'
   has-unicode-inverse: false
+  operator-name: GreaterSlantEqual
   is-letter-like: false
   unicode-equivalent: "\u2A7E"
   unicode-equivalent-name: GREATER-THAN OR SLANTED EQUAL TO
@@ -4047,6 +4085,7 @@ GreaterSlantEqual:
 GreaterTilde:
   esc-alias: '>~'
   has-unicode-inverse: false
+  operator-name: GreaterTilde
   is-letter-like: false
   unicode-equivalent: "\u2273"
   unicode-equivalent-name: GREATER-THAN OR EQUIVALENT TO
@@ -4101,6 +4140,7 @@ HorizontalLine:
 HumpDownHump:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: HumpDownHump
   unicode-equivalent: "\u224E"
   unicode-equivalent-name: GEOMETRICALLY EQUIVALENT TO
   wl-unicode: "\u224E"
@@ -4109,6 +4149,7 @@ HumpEqual:
   esc-alias: h=
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: HumpEqual
   unicode-equivalent: "\u224F"
   unicode-equivalent-name: DIFFERENCE BETWEEN
   wl-unicode: "\u224F"
@@ -4873,6 +4914,7 @@ Neptune:
 NestedGreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NestedGreaterGreater
   unicode-equivalent: "\u2AA2"
   unicode-equivalent-name: DOUBLE NESTED GREATER-THAN
   wl-unicode: "\u2AA2"
@@ -4880,6 +4922,7 @@ NestedGreaterGreater:
 NestedLessLess:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NestedLessLess
   unicode-equivalent: "\u2AA1"
   unicode-equivalent-name: DOUBLE NESTED LESS-THAN
   wl-unicode: "\u2AA1"
@@ -4915,6 +4958,7 @@ Nor:
   esc-alias: nor
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Nor
   unicode-equivalent: "\u22BD"
   unicode-equivalent-name: NOR
   operator-name: Nor
@@ -5167,6 +5211,7 @@ NotReverseElement:
 NotRightTriangle:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotRightTriangle
   unicode-equivalent: "\u22EB"
   unicode-equivalent-name: DOES NOT CONTAIN AS NORMAL SUBGROUP
   wl-unicode: "\u22EB"
@@ -5178,6 +5223,7 @@ NotRightTriangleBar:
 NotRightTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotRightTriangleEqual
   unicode-equivalent: "\u22ED"
   unicode-equivalent-name: DOES NOT CONTAIN AS NORMAL SUBGROUP OR EQUAL
   wl-unicode: "\u22ED"
@@ -5593,6 +5639,7 @@ PrecedesEqual:
 PrecedesSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: PrecedesSlantEqual
   unicode-equivalent: "\u227C"
   unicode-equivalent-name: PRECEDES OR EQUAL TO
   wl-unicode: "\u227C"
@@ -5600,16 +5647,19 @@ PrecedesSlantEqual:
 PrecedesTilde:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: PrecedesTilde
   unicode-equivalent: "\u227E"
   unicode-equivalent-name: PRECEDES OR EQUIVALENT TO
   wl-unicode: "\u227E"
   wl-unicode-name: PRECEDES OR EQUIVALENT TO
+
 # Prefix isn't really an operator
 # Prefix:
 #  ascii: "@"
 #  has-unicode-inverse: false
 #  is-letter-like: false
 #  operator-name: Prefix
+
 Prime:
   esc-alias: ''''
   has-unicode-inverse: false
@@ -5630,6 +5680,7 @@ Product:
 Proportion:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Proportion
   unicode-equivalent: "\u2237"
   unicode-equivalent-name: PROPORTION
   wl-unicode: "\u2237"
@@ -5638,6 +5689,7 @@ Proportional:
   esc-alias: prop
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Proportional
   unicode-equivalent: "\u221D"
   unicode-equivalent-name: PROPORTIONAL TO
   wl-unicode: "\u221D"
@@ -7337,6 +7389,7 @@ Unset:
 UpArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpArrow
   unicode-equivalent: "\u2191"
   unicode-equivalent-name: UPWARDS ARROW
   wl-unicode: "\u2191"
@@ -7344,6 +7397,7 @@ UpArrow:
 UpArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpArrowBar
   unicode-equivalent: "\u2912"
   unicode-equivalent-name: UPWARDS ARROW TO BAR
   wl-unicode: "\u2912"
@@ -7351,6 +7405,7 @@ UpArrowBar:
 UpArrowDownArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpArrowDownArrow
   unicode-equivalent: "\u21C5"
   unicode-equivalent-name: UPWARDS ARROW LEFTWARDS OF DOWNWARDS ARROW
   wl-unicode: "\u21C5"
@@ -7358,6 +7413,7 @@ UpArrowDownArrow:
 UpDownArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpDownArrow
   unicode-equivalent: "\u2195"
   unicode-equivalent-name: UP DOWN ARROW
   wl-unicode: "\u2195"
@@ -7365,6 +7421,7 @@ UpDownArrow:
 UpEquilibrium:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpEquilibrium
   unicode-equivalent: "\u296E"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON
     WITH BARB RIGHT
@@ -7382,6 +7439,7 @@ UpTee:
   esc-alias: uT
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpTee
   unicode-equivalent: "\u22A5"
   unicode-equivalent-name: UP TACK
   wl-unicode: "\u22A5"
@@ -7389,6 +7447,7 @@ UpTee:
 UpTeeArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpTeeArrow
   unicode-equivalent: "\u21A5"
   unicode-equivalent-name: UPWARDS ARROW FROM BAR
   wl-unicode: "\u21A5"
@@ -7396,6 +7455,7 @@ UpTeeArrow:
 UpperLeftArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpperLeftArrow
   unicode-equivalent: "\u2196"
   unicode-equivalent-name: NORTH WEST ARROW
   wl-unicode: "\u2196"
@@ -7403,6 +7463,7 @@ UpperLeftArrow:
 UpperRightArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UpperRightArrow
   unicode-equivalent: "\u2197"
   unicode-equivalent-name: NORTH EAST ARROW
   wl-unicode: "\u2197"
@@ -7442,6 +7503,7 @@ Vee:
   esc-alias: v
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Vee
   unicode-equivalent: "\u22C1"
   unicode-equivalent-name: N-ARY LOGICAL OR
   wl-unicode: "\u22C1"
@@ -7484,6 +7546,7 @@ VerticalSeparator:
 VerticalTilde:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: VerticalTilde
   unicode-equivalent: "\u2240"
   unicode-equivalent-name: WREATH PRODUCT
   wl-unicode: "\u2240"
@@ -7517,6 +7580,7 @@ Wedge:
   esc-alias: ^
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Wedge
   unicode-equivalent: "\u22C0"
   unicode-equivalent-name: N-ARY LOGICAL AND
   wl-unicode: "\u22C0"
@@ -7605,6 +7669,7 @@ Xor:
   esc-alias: xor
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Xor
   unicode-equivalent: "\u22BB"
   unicode-equivalent-name: XOR
   wl-unicode: "\u22BB"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -90,6 +90,15 @@ AHat:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH CIRCUMFLEX
   wl-unicode: "\xE2"
   wl-unicode-name: LATIN SMALL LETTER A WITH CIRCUMFLEX
+Alternative:
+  ascii: "|"
+  has-unicode-inverse: false
+  is-letter-like: false
+  operator-name: Alternative
+  unicode-equivalent: "|"
+  unicode-equivalent-name: VERTICAL LINE
+  wl-unicode: "|"
+  wl-unicode-name: VERTICAL LINE
 Apply:
   ascii: "@@"
   has-unicode-inverse: false
@@ -246,6 +255,7 @@ BeamedSixteenthNote:
 Because:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Because
   unicode-equivalent: "\u2235"
   unicode-equivalent-name: BECAUSE
   wl-unicode: "\u2235"
@@ -1083,7 +1093,7 @@ CirclePlus:
   esc-alias: c+
   has-unicode-inverse: false
   is-letter-like: false
-  operator-name: CircleMinus
+  operator-name: CirclePlus
   unicode-equivalent: "\u2295"
   unicode-equivalent-name: CIRCLED PLUS
   wl-unicode: "\u2295"
@@ -1371,7 +1381,7 @@ Definition:
 Degree:
   esc-alias: deg
   has-unicode-inverse: false
-  is-letter-like: true
+  is-letter-like: false
   operator-name: Degree
   unicode-equivalent: "\xB0"
   unicode-equivalent-name: DEGREE SIGN
@@ -4325,6 +4335,7 @@ LeftArrow:
   esc-alias: <-
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftArrow
   unicode-equivalent: "\u2190"
   unicode-equivalent-name: LEFTWARDS ARROW
   wl-unicode: "\u2190"
@@ -4332,6 +4343,7 @@ LeftArrow:
 LeftArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftArrowBar
   unicode-equivalent: "\u21E4"
   unicode-equivalent-name: LEFTWARDS ARROW TO BAR
   wl-unicode: "\u21E4"
@@ -4359,6 +4371,7 @@ LeftCeiling:
   esc-alias: lc
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftCeiling
   unicode-equivalent: "\u2308"
   unicode-equivalent-name: LEFT CEILING
   wl-unicode: "\u2308"
@@ -4381,6 +4394,7 @@ LeftDoubleBracketingBar:
 LeftDownTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftDownTeeVector
   unicode-equivalent: "\u2961"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFT FROM BAR
   wl-unicode: "\u2961"
@@ -4388,6 +4402,7 @@ LeftDownTeeVector:
 LeftDownVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftDownVector
   unicode-equivalent: "\u21C3"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFTWARDS
   wl-unicode: "\u21C3"
@@ -4395,6 +4410,7 @@ LeftDownVector:
 LeftDownVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftDownVectorBar
   unicode-equivalent: "\u2959"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFT TO BAR
   wl-unicode: "\u2959"
@@ -4403,6 +4419,7 @@ LeftFloor:
   esc-alias: lf
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftFloor
   unicode-equivalent: "\u230A"
   unicode-equivalent-name: LEFT FLOOR
   wl-unicode: "\u230A"
@@ -4423,6 +4440,7 @@ LeftModified:
 LeftPointer:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftPointer
   unicode-equivalent: "\u25C2"
   unicode-equivalent-name: BLACK LEFT-POINTING SMALL TRIANGLE
   wl-unicode: "\u25C2"
@@ -4431,6 +4449,7 @@ LeftRightArrow:
   esc-alias: <->
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftRightArrow
   unicode-equivalent: "\u2194"
   unicode-equivalent-name: LEFT RIGHT ARROW
   wl-unicode: "\u2194"
@@ -4438,6 +4457,7 @@ LeftRightArrow:
 LeftRightVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftRightVector
   unicode-equivalent: "\u294E"
   unicode-equivalent-name: LEFT BARB UP RIGHT BARB UP HARPOON
   wl-unicode: "\u294E"
@@ -4452,6 +4472,7 @@ LeftTee:
   esc-alias: lT
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftTee
   unicode-equivalent: "\u22A3"
   unicode-equivalent-name: LEFT TACK
   wl-unicode: "\u22A3"
@@ -4459,6 +4480,7 @@ LeftTee:
 LeftTeeArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftTeeArrow
   unicode-equivalent: "\u21A4"
   unicode-equivalent-name: LEFTWARDS ARROW FROM BAR
   wl-unicode: "\u21A4"
@@ -4466,6 +4488,7 @@ LeftTeeArrow:
 LeftTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftTeeVector
   unicode-equivalent: "\u295A"
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB UP FROM BAR
   wl-unicode: "\u295A"
@@ -4473,6 +4496,7 @@ LeftTeeVector:
 LeftTriangle:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftTriangle
   unicode-equivalent: "\u22B2"
   unicode-equivalent-name: NORMAL SUBGROUP OF
   wl-unicode: "\u22B2"
@@ -4480,6 +4504,7 @@ LeftTriangle:
 LeftTriangleBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftTriangleBar
   unicode-equivalent: "\u29CF"
   unicode-equivalent-name: LEFT TRIANGLE BESIDE VERTICAL BAR
   wl-unicode: "\u29CF"
@@ -4487,6 +4512,7 @@ LeftTriangleBar:
 LeftTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftTriangleEqual
   unicode-equivalent: "\u22B4"
   unicode-equivalent-name: NORMAL SUBGROUP OF OR EQUAL TO
   wl-unicode: "\u22B4"
@@ -4494,6 +4520,7 @@ LeftTriangleEqual:
 LeftUpDownVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftUpDownVector
   unicode-equivalent: "\u2951"
   unicode-equivalent-name: UP BARB LEFT DOWN BARB LEFT HARPOON
   wl-unicode: "\u2951"
@@ -4501,6 +4528,7 @@ LeftUpDownVector:
 LeftUpTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftUpTeeVector
   unicode-equivalent: "\u2960"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFT FROM BAR
   wl-unicode: "\u2960"
@@ -4508,6 +4536,7 @@ LeftUpTeeVector:
 LeftUpVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftUpVector
   unicode-equivalent: "\u21BF"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFTWARDS
   wl-unicode: "\u21BF"
@@ -4515,6 +4544,7 @@ LeftUpVector:
 LeftUpVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftUpVectorBar
   unicode-equivalent: "\u2958"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFT TO BAR
   wl-unicode: "\u2958"
@@ -4522,6 +4552,7 @@ LeftUpVectorBar:
 LeftVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LeftVector
   unicode-equivalent: "\u21BC"
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB UPWARDS
   wl-unicode: "\u21BC"
@@ -4562,6 +4593,7 @@ LessEqual:
 LessEqualGreater:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LessEqualGreater
   unicode-equivalent: "\u22DA"
   unicode-equivalent-name: LESS-THAN EQUAL TO OR GREATER-THAN
   wl-unicode: "\u22DA"
@@ -4569,6 +4601,7 @@ LessEqualGreater:
 LessFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LessFullEqual
   unicode-equivalent: "\u2266"
   unicode-equivalent-name: LESS-THAN OVER EQUAL TO
   wl-unicode: "\u2266"
@@ -4576,6 +4609,7 @@ LessFullEqual:
 LessGreater:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LessGreater
   unicode-equivalent: "\u2276"
   unicode-equivalent-name: LESS-THAN OR GREATER-THAN
   wl-unicode: "\u2276"
@@ -4583,6 +4617,7 @@ LessGreater:
 LessLess:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LessLess
   unicode-equivalent: "\u226A"
   unicode-equivalent-name: MUCH LESS-THAN
   wl-unicode: "\u226A"
@@ -4590,6 +4625,7 @@ LessLess:
 LessSlantEqual:
   esc-alias: </
   has-unicode-inverse: false
+  operator-name: LessSlantEqual
   is-letter-like: false
   unicode-equivalent: "\u2A7D"
   unicode-equivalent-name: LESS-THAN OR SLANTED EQUAL TO
@@ -4599,6 +4635,7 @@ LessTilde:
   esc-alias: <~
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LessTilde
   unicode-equivalent: "\u2272"
   unicode-equivalent-name: LESS-THAN OR EQUIVALENT TO
   wl-unicode: "\u2272"
@@ -4622,7 +4659,8 @@ LightBulb:
 LongDash:
   esc-alias: --
   has-unicode-inverse: false
-  is-letter-like: true
+  is-letter-like: false
+  operator-name: LongDash
   unicode-equivalent: "\u2014"
   unicode-equivalent-name: EM DASH
   wl-unicode: "\u2014"
@@ -4638,6 +4676,7 @@ LongLeftArrow:
   esc-alias: <--
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LongLeftArrow
   unicode-equivalent: "\u27F5"
   unicode-equivalent-name: LONG LEFTWARDS ARROW
   wl-unicode: "\u27F5"
@@ -4646,6 +4685,7 @@ LongLeftRightArrow:
   esc-alias: <-->
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LongLeftRightArrow
   unicode-equivalent: "\u27F7"
   unicode-equivalent-name: LONG LEFT RIGHT ARROW
   wl-unicode: "\u27F7"
@@ -4654,6 +4694,7 @@ LongRightArrow:
   esc-alias: -->
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LongRightArrow
   unicode-equivalent: "\u27F6"
   unicode-equivalent-name: LONG RIGHTWARDS ARROW
   wl-unicode: "\u27F6"
@@ -4661,6 +4702,7 @@ LongRightArrow:
 LowerLeftArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LowerLeftArrow
   unicode-equivalent: "\u2199"
   unicode-equivalent-name: SOUTH WEST ARROW
   wl-unicode: "\u2199"
@@ -4668,6 +4710,7 @@ LowerLeftArrow:
 LowerRightArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: LowerRightArrow
   unicode-equivalent: "\u2198"
   unicode-equivalent-name: SOUTH EAST ARROW
   wl-unicode: "\u2198"
@@ -5136,6 +5179,7 @@ NotSquareSubset:
 NotSquareSubsetEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSquareSubsetEqual
   unicode-equivalent: "\u22E2"
   unicode-equivalent-name: NOT SQUARE IMAGE OF OR EQUAL TO
   wl-unicode: "\u22E2"
@@ -5147,6 +5191,7 @@ NotSquareSuperset:
 NotSquareSupersetEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSquareSupersetEqual
   unicode-equivalent: "\u22E3"
   unicode-equivalent-name: NOT SQUARE ORIGINAL OF OR EQUAL TO
   wl-unicode: "\u22E3"
@@ -5155,6 +5200,7 @@ NotSubset:
   esc-alias: '!sub'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSubset
   unicode-equivalent: "\u2284"
   unicode-equivalent-name: NOT A SUBSET OF
   wl-unicode: "\u2284"
@@ -5163,6 +5209,7 @@ NotSubsetEqual:
   esc-alias: '!sub='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSubsetEqual
   unicode-equivalent: "\u2288"
   unicode-equivalent-name: NEITHER A SUBSET OF NOR EQUAL TO
   wl-unicode: "\u2288"
@@ -5170,6 +5217,7 @@ NotSubsetEqual:
 NotSucceeds:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSucceeds
   unicode-equivalent: "\u2281"
   unicode-equivalent-name: DOES NOT SUCCEED
   wl-unicode: "\u2281"
@@ -5181,6 +5229,7 @@ NotSucceedsEqual:
 NotSucceedsSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSucceedsSlantEqual
   unicode-equivalent: "\u22E1"
   unicode-equivalent-name: DOES NOT SUCCEED OR EQUAL
   wl-unicode: "\u22E1"
@@ -5188,6 +5237,7 @@ NotSucceedsSlantEqual:
 NotSucceedsTilde:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSucceedsTilde
   unicode-equivalent: "\u22E9"
   unicode-equivalent-name: SUCCEEDS BUT NOT EQUIVALENT TO
   wl-unicode: "\u22E9"
@@ -5196,6 +5246,7 @@ NotSuperset:
   esc-alias: '!sup'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSuperset
   unicode-equivalent: "\u2285"
   unicode-equivalent-name: NOT A SUPERSET OF
   wl-unicode: "\u2285"
@@ -5204,6 +5255,7 @@ NotSupersetEqual:
   esc-alias: '!sup='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotSupersetEqual
   unicode-equivalent: "\u2289"
   unicode-equivalent-name: NEITHER A SUPERSET OF NOR EQUAL TO
   wl-unicode: "\u2289"
@@ -5212,6 +5264,7 @@ NotTilde:
   esc-alias: '!~'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotTilde
   unicode-equivalent: "\u2241"
   unicode-equivalent-name: NOT TILDE
   wl-unicode: "\u2241"
@@ -5220,6 +5273,7 @@ NotTildeEqual:
   esc-alias: '!~='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotTildeEqual
   unicode-equivalent: "\u2244"
   unicode-equivalent-name: NOT ASYMPTOTICALLY EQUAL TO
   wl-unicode: "\u2244"
@@ -5228,6 +5282,7 @@ NotTildeFullEqual:
   esc-alias: '!~=='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotTildeFullEqual
   unicode-equivalent: "\u2247"
   unicode-equivalent-name: NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
   wl-unicode: "\u2247"
@@ -5236,6 +5291,7 @@ NotTildeTilde:
   esc-alias: '!~~'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotTildeTilde
   unicode-equivalent: "\u2249"
   unicode-equivalent-name: NOT ALMOST EQUAL TO
   wl-unicode: "\u2249"
@@ -5511,6 +5567,7 @@ Power:
 Precedes:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Precedes
   unicode-equivalent: "\u227A"
   unicode-equivalent-name: PRECEDES
   wl-unicode: "\u227A"
@@ -5518,6 +5575,7 @@ Precedes:
 PrecedesEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: PrecedesEqual
   unicode-equivalent: "\u2AAF"
   unicode-equivalent-name: PRECEDES ABOVE SINGLE-LINE EQUALS SIGN
   wl-unicode: "\u2AAF"
@@ -5554,6 +5612,7 @@ Product:
   esc-alias: prod
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Product
   unicode-equivalent: "\u220F"
   unicode-equivalent-name: N-ARY PRODUCT
   wl-unicode: "\u220F"
@@ -5672,7 +5731,7 @@ RawGreater:
   ascii: ">"
   has-unicode-inverse: true
   is-letter-like: false
-  operator-name: Greater
+  operator-name: RawGreater
   unicode-equivalent: "\u003e"
   unicode-equivalent-name: GREATER-THAN SIGN
   wl-unicode: "\u003e"
@@ -5801,7 +5860,9 @@ RawUnderscore:
   unicode-equivalent-name: LOW LINE
   wl-unicode: _
   wl-unicode-name: LOW LINE
+# RawVerticalBar is the same thing as Alternative. Go figure.
 RawVerticalBar:
+  ascii: "|"
   has-unicode-inverse: false
   is-letter-like: false
   unicode-equivalent: '|'
@@ -5861,6 +5922,7 @@ ReverseElement:
   esc-alias: mem
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ReverseElement
   unicode-equivalent: "\u220B"
   unicode-equivalent-name: CONTAINS AS MEMBER
   wl-unicode: "\u220B"
@@ -5868,6 +5930,7 @@ ReverseElement:
 ReverseEquilibrium:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ReverseEquilibrium
   unicode-equivalent: "\u21CB"
   unicode-equivalent-name: LEFTWARDS HARPOON OVER RIGHTWARDS HARPOON
   wl-unicode: "\u21CB"
@@ -5883,6 +5946,7 @@ ReversePrime:
 ReverseUpEquilibrium:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ReverseUpEquilibrium
   unicode-equivalent: "\u296F"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFT BESIDE UPWARDS HARPOON
     WITH BARB RIGHT
@@ -5916,6 +5980,7 @@ RightArrow:
   esc-alias: ' ->'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightArrow
   unicode-equivalent: "\u2192"
   unicode-equivalent-name: RIGHTWARDS ARROW
   wl-unicode: "\u2192"
@@ -5923,6 +5988,7 @@ RightArrow:
 RightArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightArrowBar
   unicode-equivalent: "\u21E5"
   unicode-equivalent-name: RIGHTWARDS ARROW TO BAR
   wl-unicode: "\u21E5"
@@ -5930,6 +5996,7 @@ RightArrowBar:
 RightArrowLeftArrow:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightArrowLeftArrow
   unicode-equivalent: "\u21C4"
   unicode-equivalent-name: RIGHTWARDS ARROW OVER LEFTWARDS ARROW
   wl-unicode: "\u21C4"
@@ -5950,6 +6017,7 @@ RightCeiling:
   esc-alias: rc
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightCeiling
   unicode-equivalent: "\u2309"
   unicode-equivalent-name: RIGHT CEILING
   wl-unicode: "\u2309"
@@ -5969,16 +6037,16 @@ RightDoubleBracket:
   wl-unicode-name: RIGHT WHITE SQUARE BRACKET
 RightDoubleBracketingBar:
   ascii: "||"
-  esc-alias: r||
   has-unicode-inverse: false
   is-letter-like: false
-  operator-name: Or
+  operator-name: RightDoubleBracketingBar
   unicode-equivalent: "\u2016"
   unicode-equivalent-name: DOUBLE VERTICAL LINE
   wl-unicode: "\uF606"
 RightDownTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightDownTeeVector
   unicode-equivalent: "\u295D"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB RIGHT FROM BAR
   wl-unicode: "\u295D"
@@ -5986,6 +6054,7 @@ RightDownTeeVector:
 RightDownVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightDownVector
   unicode-equivalent: "\u21C2"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB RIGHTWARDS
   wl-unicode: "\u21C2"
@@ -5993,6 +6062,7 @@ RightDownVector:
 RightDownVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightDownVectorBar
   unicode-equivalent: "\u2955"
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB RIGHT TO BAR
   wl-unicode: "\u2955"
@@ -6001,6 +6071,7 @@ RightFloor:
   esc-alias: rf
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightFloor
   unicode-equivalent: "\u230B"
   unicode-equivalent-name: RIGHT FLOOR
   wl-unicode: "\u230B"
@@ -6021,6 +6092,7 @@ RightModified:
 RightPointer:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightPointer
   unicode-equivalent: "\u25B8"
   unicode-equivalent-name: BLACK RIGHT-POINTING SMALL TRIANGLE
   wl-unicode: "\u25B8"
@@ -6034,6 +6106,7 @@ RightSkeleton:
 RightTee:
   esc-alias: rT
   has-unicode-inverse: false
+  operator-name: RightTee
   is-letter-like: false
   unicode-equivalent: "\u22A2"
   unicode-equivalent-name: RIGHT TACK
@@ -6049,6 +6122,7 @@ RightTeeArrow:
 RightTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightTeeVector
   unicode-equivalent: "\u295B"
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB UP FROM BAR
   wl-unicode: "\u295B"
@@ -6056,6 +6130,7 @@ RightTeeVector:
 RightTriangle:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightTriangle
   unicode-equivalent: "\u22B3"
   unicode-equivalent-name: CONTAINS AS NORMAL SUBGROUP
   wl-unicode: "\u22B3"
@@ -6063,6 +6138,7 @@ RightTriangle:
 RightTriangleBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightTriangleBar
   unicode-equivalent: "\u29D0"
   unicode-equivalent-name: VERTICAL BAR BESIDE RIGHT TRIANGLE
   wl-unicode: "\u29D0"
@@ -6070,12 +6146,14 @@ RightTriangleBar:
 RightTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightTriangleEqual
   unicode-equivalent: "\u22B5"
   unicode-equivalent-name: CONTAINS AS NORMAL SUBGROUP OR EQUAL TO
   wl-unicode: "\u22B5"
   wl-unicode-name: CONTAINS AS NORMAL SUBGROUP OR EQUAL TO
 RightUpDownVector:
   has-unicode-inverse: false
+  operator-name: RightUpDownVector
   is-letter-like: false
   unicode-equivalent: "\u294F"
   unicode-equivalent-name: UP BARB RIGHT DOWN BARB RIGHT HARPOON
@@ -6084,6 +6162,7 @@ RightUpDownVector:
 RightUpTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightUpTeeVector
   unicode-equivalent: "\u295C"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB RIGHT FROM BAR
   wl-unicode: "\u295C"
@@ -6091,6 +6170,7 @@ RightUpTeeVector:
 RightUpVector:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightUpVector
   unicode-equivalent: "\u21BE"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB RIGHTWARDS
   wl-unicode: "\u21BE"
@@ -6098,6 +6178,7 @@ RightUpVector:
 RightUpVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightUpVectorBar
   unicode-equivalent: "\u2954"
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB RIGHT TO BAR
   wl-unicode: "\u2954"
@@ -6106,6 +6187,7 @@ RightVector:
   esc-alias: vec
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightVector
   unicode-equivalent: "\u21C0"
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB UPWARDS
   wl-unicode: "\u21C0"
@@ -6113,6 +6195,7 @@ RightVector:
 RightVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RightVectorBar
   unicode-equivalent: "\u2953"
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB UP TO BAR
   wl-unicode: "\u2953"
@@ -6120,6 +6203,7 @@ RightVectorBar:
 RoundImplies:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: RoundImplies
   unicode-equivalent: "\u2970"
   unicode-equivalent-name: RIGHT DOUBLE ARROW WITH ROUNDED HEAD
   wl-unicode: "\u2970"
@@ -6787,6 +6871,7 @@ Sqrt:
   esc-alias: sqrt
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Sqrt
   unicode-equivalent: "\u221A"
   unicode-equivalent-name: SQUARE ROOT
   wl-unicode: "\u221A"
@@ -6801,6 +6886,7 @@ Square:
 SquareIntersection:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SquareIntersection
   unicode-equivalent: "\u2293"
   unicode-equivalent-name: SQUARE CAP
   wl-unicode: "\u2293"
@@ -6808,6 +6894,7 @@ SquareIntersection:
 SquareSubset:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SquareSubset
   unicode-equivalent: "\u228F"
   unicode-equivalent-name: SQUARE IMAGE OF
   wl-unicode: "\u228F"
@@ -6815,6 +6902,7 @@ SquareSubset:
 SquareSubsetEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SquareSubsetEqual
   unicode-equivalent: "\u2291"
   unicode-equivalent-name: SQUARE IMAGE OF OR EQUAL TO
   wl-unicode: "\u2291"
@@ -6822,6 +6910,7 @@ SquareSubsetEqual:
 SquareSuperset:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SquareSuperset
   unicode-equivalent: "\u2290"
   unicode-equivalent-name: SQUARE ORIGINAL OF
   wl-unicode: "\u2290"
@@ -6829,6 +6918,7 @@ SquareSuperset:
 SquareSupersetEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SquareSupersetEqual
   unicode-equivalent: "\u2292"
   unicode-equivalent-name: SQUARE ORIGINAL OF OR EQUAL TO
   wl-unicode: "\u2292"
@@ -6836,6 +6926,7 @@ SquareSupersetEqual:
 SquareUnion:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SquareUnion
   unicode-equivalent: "\u2294"
   unicode-equivalent-name: SQUARE CUP
   wl-unicode: "\u2294"
@@ -6877,6 +6968,7 @@ Subset:
   esc-alias: sub
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Subset
   unicode-equivalent: "\u2282"
   unicode-equivalent-name: SUBSET OF
   wl-unicode: "\u2282"
@@ -6885,6 +6977,7 @@ SubsetEqual:
   esc-alias: sub=
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SubsetEqual
   unicode-equivalent: "\u2286"
   unicode-equivalent-name: SUBSET OF OR EQUAL TO
   wl-unicode: "\u2286"
@@ -6899,11 +6992,13 @@ Succeeds:
   is-letter-like: false
   unicode-equivalent: "\u227B"
   unicode-equivalent-name: SUCCEEDS
+  operator-name: Succeeds
   wl-unicode: "\u227B"
   wl-unicode-name: SUCCEEDS
 SucceedsEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SucceedsEqual
   unicode-equivalent: "\u2AB0"
   unicode-equivalent-name: SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN
   wl-unicode: "\u2AB0"
@@ -6911,6 +7006,7 @@ SucceedsEqual:
 SucceedsSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SucceedsSlantEqual
   unicode-equivalent: "\u227D"
   unicode-equivalent-name: SUCCEEDS OR EQUAL TO
   wl-unicode: "\u227D"
@@ -6918,6 +7014,7 @@ SucceedsSlantEqual:
 SucceedsTilde:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SucceedsTilde
   unicode-equivalent: "\u227F"
   unicode-equivalent-name: SUCCEEDS OR EQUIVALENT TO
   wl-unicode: "\u227F"
@@ -6926,6 +7023,7 @@ SuchThat:
   esc-alias: st
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SuchThat
   unicode-equivalent: "\u220D"
   unicode-equivalent-name: SMALL CONTAINS AS MEMBER
   wl-unicode: "\u220D"
@@ -6934,6 +7032,7 @@ Sum:
   esc-alias: sum
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Sum
   unicode-equivalent: "\u2211"
   unicode-equivalent-name: N-ARY SUMMATION
   wl-unicode: "\u2211"
@@ -6942,6 +7041,7 @@ Superset:
   esc-alias: sup
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Superset
   unicode-equivalent: "\u2283"
   unicode-equivalent-name: SUPERSET OF
   wl-unicode: "\u2283"
@@ -6950,6 +7050,7 @@ SupersetEqual:
   esc-alias: sup=
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: SupersetEqual
   unicode-equivalent: "\u2287"
   unicode-equivalent-name: SUPERSET OF OR EQUAL TO
   wl-unicode: "\u2287"
@@ -7009,6 +7110,7 @@ Therefore:
   esc-alias: tf
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Therefore
   unicode-equivalent: "\u2234"
   unicode-equivalent-name: THEREFORE
   wl-unicode: "\u2234"
@@ -7055,6 +7157,7 @@ TildeEqual:
   esc-alias: ~=
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: TildeEqual
   unicode-equivalent: "\u2243"
   unicode-equivalent-name: ASYMPTOTICALLY EQUAL TO
   wl-unicode: "\u2243"
@@ -7063,6 +7166,7 @@ TildeFullEqual:
   esc-alias: ~==
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: TildeFullEqual
   unicode-equivalent: "\u2245"
   unicode-equivalent-name: APPROXIMATELY EQUAL TO
   wl-unicode: "\u2245"
@@ -7071,6 +7175,7 @@ TildeTilde:
   esc-alias: ~~
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: TildeTilde
   unicode-equivalent: "\u2248"
   unicode-equivalent-name: ALMOST EQUAL TO
   wl-unicode: "\u2248"
@@ -7201,6 +7306,7 @@ Union:
   esc-alias: un
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Union
   unicode-equivalent: "\u22C3"
   unicode-equivalent-name: N-ARY UNION
   wl-unicode: "\u22C3"
@@ -7208,6 +7314,7 @@ Union:
 UnionPlus:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: UnionPlus
   unicode-equivalent: "\u228E"
   unicode-equivalent-name: MULTISET UNION
   wl-unicode: "\u228E"
@@ -7337,14 +7444,13 @@ Venus:
   wl-unicode: "\u2640"
   wl-unicode-name: FEMALE SIGN
 VerticalBar:
-  ascii: "|"
   esc-alias: ' |'
   has-unicode-inverse: true
   is-letter-like: false
-  operator-name: Alternatives
-  unicode-equivalent: "\u007C"
-  unicode-equivalent-name: VERTICAL LINE
+  unicode-equivalent: "\u2758"
+  unicode-equivalent-name: VERTICAL BAR
   wl-unicode: "\uF3D0"
+  wl-unicode-name: LIGHT VERTICAL BAR
 VerticalEllipsis:
   has-unicode-inverse: false
   is-letter-like: false

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1386,22 +1386,30 @@ Definition:
   is-letter-like: false
   operator-name: Definition
 
-# Using \[Degree] as an operator messes up Mathics parsing,
-# But mathics-pygments would like this to be an operator.
-# We adjust for that in the mathics-pygments code.
+# \[Degree] is letter-like, not an operator, which is
+# mutually exclusive.
 
-# Also, in order too be able to write:
-#   \[Degree] == Degree,
-# \Degree has to be letter-like.
+# Therefore, when we write 360° that is analogous to 2π, pun intended,
+# it this interpreted as: 360 times "degree", and analogous to: 2 times
+# "pi".
+
+# Note that writing:
+#  \[Degree] == Degree
+# is valid, and this would not be the case if this symbol were
+# not letterlike.
+
+# However mathics-pygments currently would like this to be an
+# operator, (which might be wrong). At any rate, adjust for that in
+# the mathics-pygments code as desired.
 Degree:
   esc-alias: deg
   has-unicode-inverse: false
   is-letter-like: true
-  # operator-name: Degree
   unicode-equivalent: "\xB0"
   unicode-equivalent-name: DEGREE SIGN
   wl-unicode: "\xB0"
   wl-unicode-name: DEGREE SIGN
+
 Del:
   esc-alias: del
   has-unicode-inverse: false

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1027,6 +1027,7 @@ CenterDot:
   esc-alias: .
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CenterDot
   unicode-equivalent: "\xB7"
   unicode-equivalent-name: MIDDLE DOT
   wl-unicode: "\xB7"
@@ -1064,6 +1065,7 @@ CircleDot:
   esc-alias: c.
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CircleDot
   unicode-equivalent: "\u2299"
   unicode-equivalent-name: CIRCLED DOT OPERATOR
   wl-unicode: "\u2299"
@@ -1072,6 +1074,7 @@ CircleMinus:
   esc-alias: c-
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CircleMinus
   unicode-equivalent: "\u2296"
   unicode-equivalent-name: CIRCLED MINUS
   wl-unicode: "\u2296"
@@ -1080,6 +1083,7 @@ CirclePlus:
   esc-alias: c+
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CircleMinus
   unicode-equivalent: "\u2295"
   unicode-equivalent-name: CIRCLED PLUS
   wl-unicode: "\u2295"
@@ -1088,6 +1092,7 @@ CircleTimes:
   esc-alias: c*
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CircleTimes
   unicode-equivalent: "\u2297"
   unicode-equivalent-name: CIRCLED TIMES
   wl-unicode: "\u2297"
@@ -1096,6 +1101,7 @@ ClockwiseContourIntegral:
   esc-alias: ccint
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ClockwiseContourIntegral
   unicode-equivalent: "\u2232"
   unicode-equivalent-name: CLOCKWISE CONTOUR INTEGRAL
   wl-unicode: "\u2232"
@@ -1201,6 +1207,7 @@ ContourIntegral:
   esc-alias: cint
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ContourIntegral
   unicode-equivalent: "\u222E"
   unicode-equivalent-name: CONTOUR INTEGRAL
   wl-unicode: "\u222E"
@@ -1229,6 +1236,7 @@ CounterClockwiseContourIntegral:
   esc-alias: cccint
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: CounterClockwiseContourIntegral
   unicode-equivalent: "\u2233"
   unicode-equivalent-name: ANTICLOCKWISE CONTOUR INTEGRAL
   wl-unicode: "\u2233"
@@ -1364,6 +1372,7 @@ Degree:
   esc-alias: deg
   has-unicode-inverse: false
   is-letter-like: true
+  operator-name: Degree
   unicode-equivalent: "\xB0"
   unicode-equivalent-name: DEGREE SIGN
   wl-unicode: "\xB0"
@@ -1372,6 +1381,7 @@ Del:
   esc-alias: del
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Del
   unicode-equivalent: "\u2207"
   unicode-equivalent-name: NABLA
   wl-unicode: "\u2207"
@@ -1534,6 +1544,7 @@ DotEqual:
   esc-alias: .=
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DotEqual
   unicode-equivalent: "\u2250"
   unicode-equivalent-name: APPROACHES THE LIMIT
   wl-unicode: "\u2250"
@@ -1560,6 +1571,7 @@ DottedSquare:
 DoubleContourIntegral:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DoubleContourIntegral
   unicode-equivalent: "\u222F"
   unicode-equivalent-name: SURFACE INTEGRAL
   wl-unicode: "\u222F"
@@ -2315,6 +2327,7 @@ Element:
   esc-alias: el
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Element
   unicode-equivalent: "\u2208"
   unicode-equivalent-name: ELEMENT OF
   wl-unicode: "\u2208"
@@ -2493,6 +2506,7 @@ Exists:
   esc-alias: ex
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Exists
   unicode-equivalent: "\u2203"
   unicode-equivalent-name: THERE EXISTS
   wl-unicode: "\u2203"
@@ -4189,6 +4203,7 @@ Integral:
   esc-alias: int
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Integral
   unicode-equivalent: "\u222B"
   unicode-equivalent-name: INTEGRAL
   wl-unicode: "\u222B"
@@ -4196,6 +4211,7 @@ Integral:
 Intersection:
   esc-alias: inter
   has-unicode-inverse: false
+  operator-name: Intersection
   is-letter-like: false
   unicode-equivalent: "\u22C2"
   unicode-equivalent-name: N-ARY INTERSECTION
@@ -4848,18 +4864,21 @@ Nor:
   is-letter-like: false
   unicode-equivalent: "\u22BD"
   unicode-equivalent-name: NOR
+  operator-name: Nor
   wl-unicode: "\u22BD"
   wl-unicode-name: NOR
 Not:
   esc-alias: '!'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Not
   wl-unicode: "\xAC"
   wl-unicode-name: NOT SIGN
 NotCongruent:
   esc-alias: '!==='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotCongruent
   unicode-equivalent: "\u2262"
   unicode-equivalent-name: NOT IDENTICAL TO
   wl-unicode: "\u2262"
@@ -4867,6 +4886,7 @@ NotCongruent:
 NotCupCap:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotCupCap
   unicode-equivalent: "\u226D"
   unicode-equivalent-name: NOT EQUIVALENT TO
   wl-unicode: "\u226D"
@@ -4875,6 +4895,7 @@ NotDoubleVerticalBar:
   esc-alias: '!||'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotDoubleVerticalBar
   unicode-equivalent: "\u2226"
   unicode-equivalent-name: NOT PARALLEL TO
   wl-unicode: "\u2226"
@@ -4883,6 +4904,7 @@ NotElement:
   esc-alias: '!el'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotElement
   unicode-equivalent: "\u2209"
   unicode-equivalent-name: NOT AN ELEMENT OF
   wl-unicode: "\u2209"
@@ -4906,6 +4928,7 @@ NotExists:
   esc-alias: '!ex'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotExists
   unicode-equivalent: "\u2204"
   unicode-equivalent-name: THERE DOES NOT EXIST
   wl-unicode: "\u2204"
@@ -4914,6 +4937,7 @@ NotGreater:
   esc-alias: '!>'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotGreater
   unicode-equivalent: "\u226F"
   unicode-equivalent-name: NOT GREATER-THAN
   wl-unicode: "\u226F"
@@ -4922,6 +4946,7 @@ NotGreaterEqual:
   esc-alias: '!>='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotGreaterEqual
   unicode-equivalent: "\u2271"
   unicode-equivalent-name: NEITHER GREATER-THAN NOR EQUAL TO
   wl-unicode: "\u2271"
@@ -4929,6 +4954,7 @@ NotGreaterEqual:
 NotGreaterFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotGreaterFullEqual
   unicode-equivalent: "\u2269"
   unicode-equivalent-name: GREATER-THAN BUT NOT EQUAL TO
   wl-unicode: "\u2269"
@@ -4936,10 +4962,12 @@ NotGreaterFullEqual:
 NotGreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotGreaterGreater
   wl-unicode: "\uF427"
 NotGreaterLess:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotGreaterLess
   unicode-equivalent: "\u2279"
   unicode-equivalent-name: NEITHER GREATER-THAN NOR LESS-THAN
   wl-unicode: "\u2279"
@@ -4953,6 +4981,7 @@ NotGreaterTilde:
   esc-alias: '!>~'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotGreaterTilde
   unicode-equivalent: "\u2275"
   unicode-equivalent-name: NEITHER GREATER-THAN NOR EQUIVALENT TO
   wl-unicode: "\u2275"
@@ -4969,6 +4998,7 @@ NotHumpEqual:
 NotLeftTriangle:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLeftTriangle
   unicode-equivalent: "\u22EA"
   unicode-equivalent-name: NOT NORMAL SUBGROUP OF
   wl-unicode: "\u22EA"
@@ -4980,6 +5010,7 @@ NotLeftTriangleBar:
 NotLeftTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLeftTriangleEqual
   unicode-equivalent: "\u22EC"
   unicode-equivalent-name: NOT NORMAL SUBGROUP OF OR EQUAL TO
   wl-unicode: "\u22EC"
@@ -4988,6 +5019,7 @@ NotLess:
   esc-alias: '!<'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLess
   unicode-equivalent: "\u226E"
   unicode-equivalent-name: NOT LESS-THAN
   wl-unicode: "\u226E"
@@ -4996,6 +5028,7 @@ NotLessEqual:
   esc-alias: '!<='
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLessEqual
   unicode-equivalent: "\u2270"
   unicode-equivalent-name: NEITHER LESS-THAN NOR EQUAL TO
   wl-unicode: "\u2270"
@@ -5003,6 +5036,7 @@ NotLessEqual:
 NotLessFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLessFullEqual
   unicode-equivalent: "\u2268"
   unicode-equivalent-name: LESS-THAN BUT NOT EQUAL TO
   wl-unicode: "\u2268"
@@ -5010,6 +5044,7 @@ NotLessFullEqual:
 NotLessGreater:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotLessGreater
   unicode-equivalent: "\u2278"
   unicode-equivalent-name: NEITHER LESS-THAN NOR GREATER-THAN
   wl-unicode: "\u2278"
@@ -5042,6 +5077,7 @@ NotNestedLessLess:
 NotPrecedes:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotPrecedes
   unicode-equivalent: "\u2280"
   unicode-equivalent-name: DOES NOT PRECEDE
   wl-unicode: "\u2280"
@@ -5053,6 +5089,7 @@ NotPrecedesEqual:
 NotPrecedesSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotPrecedesSlantEqual
   unicode-equivalent: "\u22E0"
   unicode-equivalent-name: DOES NOT PRECEDE OR EQUAL
   wl-unicode: "\u22E0"
@@ -5060,6 +5097,7 @@ NotPrecedesSlantEqual:
 NotPrecedesTilde:
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotPrecedesTilde
   unicode-equivalent: "\u22E8"
   unicode-equivalent-name: PRECEDES BUT NOT EQUIVALENT TO
   wl-unicode: "\u22E8"
@@ -5068,6 +5106,7 @@ NotReverseElement:
   esc-alias: '!mem'
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: NotReverseElement
   unicode-equivalent: "\u220C"
   unicode-equivalent-name: DOES NOT CONTAIN AS MEMBER
   wl-unicode: "\u220C"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -6,7 +6,7 @@
 #   esc-alias: The ESC sequence alias of the named character, if it exists.
 #
 #   has-unicode-inverse: Whether or not this named character has a unicode
-#                        equivalent that should replace other variants of it, 
+#                        equivalent that should replace other variants of it,
 #                        e.g. named character or ascii equivalent.
 #
 #   is-letter-like: Whether or not this named-character is "letter-like".
@@ -1378,13 +1378,18 @@ Definition:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Definition
-# Using Degree as an operator messes up parsing.
-# mathics-pygments would like this to be an operator.
-# We adjust for that in that code
+
+ # Using Degree as an operator messes up parsing,
+# but mathics-pygments would like this to be an operator.
+# We adjust for that in the mathics-pygments code
+
+# Also, in order for theto be able to write:
+# \[Degree] == Degree,
+# \Degree has to be letter-like.
 Degree:
   esc-alias: deg
   has-unicode-inverse: false
-  is-letter-like: false
+  is-letter-like: true
   # operator-name: Degree
   unicode-equivalent: "\xB0"
   unicode-equivalent-name: DEGREE SIGN

--- a/mathics_scanner/generate/.gitignore
+++ b/mathics_scanner/generate/.gitignore
@@ -1,2 +1,1 @@
 /.python-version
-/.python-version

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -128,9 +128,9 @@ def compile_tables(data: dict) -> dict:
         k: v["wl-unicode"] for k, v in data.items() if "wl-unicode" in v
     }
 
-    # ESC sequence aliases
+    # Operators with ASCII sequences
     ascii_operators = sorted([
-        v["ascii"] for v in data.values() if "operator-name" in v
+        v["ascii"] for v in data.values() if "operator-name" in v and "ascii" in v
     ])
 
     # ESC sequence aliases
@@ -145,6 +145,12 @@ def compile_tables(data: dict) -> dict:
         if "operator-name" in v and "unicode-equivalent" in v
     }
 
+    # ESC sequence aliases
+    unicode_operators = sorted([
+        v["unicode-equivalent"] for v in data.values() if "operator-name" in v and "unicode-equivalent" in v
+    ])
+
+
     # operator-to-unicode dictionary
     unicode_to_operator = {
         v["unicode-equivalent"]: v["operator-name"]
@@ -157,6 +163,7 @@ def compile_tables(data: dict) -> dict:
         "letterlikes": letterlikes,
         "named-characters": named_characters,
         "operator-to-unicode": operator_to_unicode,
+        "unicode-operators": unicode_operators,
         "unicode-to-operator": unicode_to_operator,
         "unicode-to-wl-dict": unicode_to_wl_dict,
         "unicode-to-wl-re": unicode_to_wl_re,
@@ -175,6 +182,7 @@ ALL_FIELDS = [
     "letterlikes",
     "named-characters",
     "operator-to-unicode",
+    "unicode-operators",
     "unicode-to-operator",
     "unicode-to-wl-dict",
     "unicode-to-wl-re",

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -129,6 +129,11 @@ def compile_tables(data: dict) -> dict:
     }
 
     # ESC sequence aliases
+    ascii_operators = sorted([
+        v["ascii"] for v in data.values() if "operator-name" in v
+    ])
+
+    # ESC sequence aliases
     aliased_characters = {
         v["esc-alias"]: v["wl-unicode"] for v in data.values() if "esc-alias" in v
     }
@@ -148,6 +153,7 @@ def compile_tables(data: dict) -> dict:
     }
     return {
         "aliased-characters": aliased_characters,
+        "ascii-operators": ascii_operators,
         "letterlikes": letterlikes,
         "named-characters": named_characters,
         "operator-to-unicode": operator_to_unicode,
@@ -165,6 +171,7 @@ DEFAULT_DATA_DIR = Path(osp.normpath(osp.dirname(__file__)), "..", "data")
 
 ALL_FIELDS = [
     "aliased-characters",
+    "ascii-operators",
     "letterlikes",
     "named-characters",
     "operator-to-unicode",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 PyYAML
 click
+pytest

--- a/test/test_general_yaml_sanity.py
+++ b/test/test_general_yaml_sanity.py
@@ -88,7 +88,7 @@ def test_wl_unicode_name():
 
         try:
             expected_name = unicodedata.name(wl)
-        except ValueError:
+        except (ValueError, TypeError):
             continue
 
         real_name = v.get("wl-unicode-name")


### PR DESCRIPTION
These add the `unicode-operator` field to indicate which Unicode symbols are binary operators with no built-in meaning. 

These are used in mathics-pygments.