### PR TITLE
Update setup.py: Use SPDX identifier for license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     # metadata for upload to PyPI
     maintainer="Mathics Group",
     description="Character Tables and Tokenizer for Mathics and the Wolfram Language.",
-    license="GPL",
+    license="GPL-3.0-only",
     url="https://mathics.org/",
     keywords=["Mathematica", "Wolfram", "Interpreter", "Shell", "Math", "CAS"],
     classifiers=[


### PR DESCRIPTION
Use SPDX[1] license identifier for portable packaging.

[1] https://spdx.org/licenses/