### PR TITLE
Accept \u21A6 as symbol for Function.

### DIFF
--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -3744,6 +3744,7 @@ Function:
   unicode-equivalent-name: RIGHTWARDS ARROW FROM BAR
   wl-unicode: "\uF4A1"
   wl-unicode-name: RIGHTWARDS ARROW FROM BAR
+  precedence: 800
 
 # Alternative form of Function. We use FunctionAmpersand
 # since Function is already taken. See note above.

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -3749,10 +3749,9 @@ Function:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Function
-  # precedence 720 may be a bit high and it might turn out to need lowering.
-  # However we need something greater than Alternative "|" which is
+  # This needs to be greater than Alternative "|" which is
   # 160 so that we don't treat |-> as | ->.
-  precedence: 720
+  precedence: 161
   unicode-equivalent: "\u21A6"
   unicode-equivalent-name: RIGHTWARDS ARROW FROM BAR
   wl-unicode: "\uF4A1"

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -22,7 +22,15 @@
 #                  whose class name is the given name. For example Divide.
 #
 #   precedence: If present, this symbol is a Mathics operator with the
-#               specific numeric precidence value.
+#               specific numeric precedence value. A higher value means that
+#               the operator binds before an operator with a lower value.
+#               For example the Times precedence 400 is higher than the
+#               Plus precedence 310 because a + b * c is a + (b * c),
+#               not (a + b) * c.
+#               Precedence is also used to force multi-character ASCII
+#               symbols like |-> to get treated as one unit and not
+#               split into two operators like | and ->. So the precedence
+#               of |-> has to be higher than |.
 #
 #   unicode-equivalent: A unicode equivalent for the named-character, if it
 #                       exists. If it is the same as "ascii", please omit.
@@ -1249,6 +1257,7 @@ Colon:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Colon
+  precedence: 80
   unicode-equivalent: "\u2236"
   unicode-equivalent-name: RATIO
   wl-unicode: "\u2236"
@@ -3740,11 +3749,14 @@ Function:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Function
+  # precedence 720 may be a bit high and it might turn out to need lowering.
+  # However we need something greater than Alternative "|" which is
+  # 160 so that we don't treat |-> as | ->.
+  precedence: 720
   unicode-equivalent: "\u21A6"
   unicode-equivalent-name: RIGHTWARDS ARROW FROM BAR
   wl-unicode: "\uF4A1"
   wl-unicode-name: RIGHTWARDS ARROW FROM BAR
-  precedence: 800
 
 # Alternative form of Function. We use FunctionAmpersand
 # since Function is already taken. See note above.

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -259,7 +259,6 @@ literal_tokens = {
     "^": ["UpSetDelayed", "UpSet", "Power"],
     "_": ["Pattern"],
     "`": ["Pattern", "Symbol"],
-    # FIXME: the -> part of |-> in function isn't handled
     "|": ["RawRightAssociation", "Or", "Alternatives", "Function"],
     "{": ["RawLeftBrace"],
     "}": ["RawRightBrace"],

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -133,7 +133,7 @@ tokens = [
     ("RawBackslash", r" \\ "),
     ("Factorial2", r" \!\! "),
     ("Factorial", r" \! "),
-    ("Function", r" \& | \uF4A1 "),
+    ("Function", r" \& | \uF4A1 | \u21A6 | \|-> "),
     ("RawColon", r" \: "),
     # ('DiscreteShift', r' \uf4a3 '),
     # ('DiscreteRatio', r' \uf4a4 '),
@@ -259,7 +259,8 @@ literal_tokens = {
     "^": ["UpSetDelayed", "UpSet", "Power"],
     "_": ["Pattern"],
     "`": ["Pattern", "Symbol"],
-    "|": ["RawRightAssociation", "Or", "Alternatives"],
+    # FIXME: the -> part of |-> in function isn't handled
+    "|": ["RawRightAssociation", "Or", "Alternatives", "Function"],
     "{": ["RawLeftBrace"],
     "}": ["RawRightBrace"],
     "~": ["StringExpression", "Infix"],
@@ -283,7 +284,9 @@ def find_indices(literals) -> dict:
                 if tag == tag2:
                     indices.append(i)
                     break
-        assert len(indices) == len(tags)
+        assert len(indices) == len(
+            tags
+        ), f"problem mathching tokens for symbol {key} having tags {tags}"
         literal_indices[key] = tuple(indices)
     return literal_indices
 

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -286,7 +286,7 @@ def find_indices(literals) -> dict:
                     break
         assert len(indices) == len(
             tags
-        ), f"problem mathching tokens for symbol {key} having tags {tags}"
+        ), f"problem matching tokens for symbol {key} having tags {tags}"
         literal_indices[key] = tuple(indices)
     return literal_indices
 


### PR DESCRIPTION
This recognizes the recently added \u21A6 an operator for `Function`. 

However the ASCII equivalent `|->` still is broken. 