### PR TITLE
Corrections/additions to Transpose and Conjugate

### DIFF
--- a/.github/workflows/mathics.yml
+++ b/.github/workflows/mathics.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Test Mathics
       run: |
         # Until next Mathics3/mathics-core release is out...
-        python -m pip install -e git://github.com/Mathics3/mathics-core#egg=Mathics3[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-core#egg=Mathics3[full]
         # pip install Mathics3[full]
         make check-mathics

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1305,11 +1305,13 @@ Conjugate:
   esc-alias: co
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: Conjugate
   wl-unicode: "\uF3C8"
 ConjugateTranspose:
   esc-alias: ct
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: ConjugateTranspose
   wl-unicode: "\uF3C9"
 ConstantC:
   esc-alias: cc
@@ -7627,6 +7629,7 @@ Transpose:
   esc-alias: tr
   has-unicode-inverse: true
   is-letter-like: false
+  operator-name: Transpose
   unicode-equivalent: "\u1D40"
   unicode-equivalent-name: MODIFIER LETTER CAPITAL T
   wl-unicode: "\uF3C7"

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -141,7 +141,8 @@ tokens = [
     # ('PartialD', r' \u2202 '),
     ("Cross", r" \uf4a0 "),
     ("Colon", r" \u2236 "),
-    ("Transpose", r" \uf3c7 "),
+    # uf3c7 is Wolfram custom, 1d40 is unicode
+    ("Transpose", r" \uf3c7 | \u1d40"),
     ("Conjugate", r" \uf3c8 "),
     ("ConjugateTranspose", r" \uf3c9 "),
     ("HermitianConjugate", r" \uf3ce "),

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -139,9 +139,10 @@ tokens = [
     # ('DiscreteRatio', r' \uf4a4 '),
     # ('DifferenceDelta', r' \u2206 '),
     # ('PartialD', r' \u2202 '),
-    ("Cross", r" \uf4a0 "),
+    # uf4a0 is Wolfram custom, u2a2f is standard unicode
+    ("Cross", r" \uf4a0 | \u2a2f"),
     ("Colon", r" \u2236 "),
-    # uf3c7 is Wolfram custom, 1d40 is unicode
+    # uf3c7 is Wolfram custom, 1d40 is standard unicode
     ("Transpose", r" \uf3c7 | \u1d40"),
     ("Conjugate", r" \uf3c8 "),
     ("ConjugateTranspose", r" \uf3c9 "),
@@ -149,7 +150,8 @@ tokens = [
     ("Integral", r" \u222b "),
     ("DifferentialD", r" \U0001D451 "),
     ("Del", r" \u2207 "),
-    ("Square", r" \uf520 "),
+    # uf520 is Wolfram custom, 25ab is standard unicode
+    ("Square", r" \uf520 | \u25ab"),
     ("SmallCircle", r" \u2218 "),
     ("CircleDot", r" \u2299 "),
     # ('Sum', r' \u2211 '),


### PR DESCRIPTION
* tokeniser.py: include unicode value in addition to WL custom value
* named-characters.yml: note Transpose, Conjugate, and ConjugateTranspose are operators

In the future though we want to break out *what* kind of operator, e.g postfix, prefix, infix