### PR TITLE
revert wl-code->unicode-equivalent in parsing. Adding amstex tables

### DIFF
--- a/mathics_scanner/characters.py
+++ b/mathics_scanner/characters.py
@@ -58,6 +58,9 @@ named_characters = _data.get("named-characters", {})
 aliased_characters = _data.get("aliased-characters", {})
 
 
+# AMSTeX replacements
+amstex_characters = _data.get("amstex_characters", None)
+
 def replace_wl_with_plain_text(wl_input: str, use_unicode=True) -> str:
     """
     The Wolfram Language uses specific Unicode characters to represent Wolfram

--- a/mathics_scanner/characters.py
+++ b/mathics_scanner/characters.py
@@ -61,6 +61,7 @@ aliased_characters = _data.get("aliased-characters", {})
 # AMSTeX replacements
 amstex_characters = _data.get("amstex_characters", None)
 
+
 def replace_wl_with_plain_text(wl_input: str, use_unicode=True) -> str:
     """
     The Wolfram Language uses specific Unicode characters to represent Wolfram

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -97,6 +97,13 @@ def compile_tables(data: dict) -> dict:
         if "esc-alias" in v
     }
 
+    # AMSTEX operators
+    amstex_characters = {
+        v["wl-unicode"]: v.get("amslatex", v.get("wl-unicode"))
+        for v in data.values()
+        if "amslatex" in v and "wl-unicode" in v
+    }
+
     # operator-to-unicode dictionary entry
     operator_to_precedence = {
         v["operator-name"]: v["precedence"]
@@ -130,9 +137,7 @@ def compile_tables(data: dict) -> dict:
 
     # All supported named characters dictionary entry
     named_characters = {
-        k: v.get("unicode-equivalent", v.get("wl-unicode"))
-        for k, v in data.items()
-        if "wl-unicode" in v
+        k: v["wl-unicode"] for k, v in data.items() if "wl-unicode" in v
     }
 
     # Operators with ASCII sequences list entry
@@ -176,6 +181,7 @@ def compile_tables(data: dict) -> dict:
 
     return {
         "aliased-characters": aliased_characters,
+        "amstex_characters" : amstex_characters,
         "ascii-operators": ascii_operators,
         "letterlikes": letterlikes,
         "named-characters": named_characters,
@@ -196,6 +202,7 @@ def compile_tables(data: dict) -> dict:
 DEFAULT_DATA_DIR = Path(osp.normpath(osp.dirname(__file__)), "..", "data")
 
 ALL_FIELDS = [
+    "amstex_characters",
     "aliased-characters",
     "ascii-operators",
     "letterlikes",

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -181,7 +181,7 @@ def compile_tables(data: dict) -> dict:
 
     return {
         "aliased-characters": aliased_characters,
-        "amstex_characters" : amstex_characters,
+        "amstex_characters": amstex_characters,
         "ascii-operators": ascii_operators,
         "letterlikes": letterlikes,
         "named-characters": named_characters,

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -148,7 +148,7 @@ tokens = [
     ("ConjugateTranspose", r" \uf3c9 "),
     ("HermitianConjugate", r" \uf3ce "),
     ("Integral", r" \u222b "),
-    ("DifferentialD", r" \U0001D451 "),
+    ("DifferentialD", r" \u1d451 | \uf74c"),
     ("Del", r" \u2207 "),
     # uf520 is Wolfram custom, 25ab is standard unicode
     ("Square", r" \uf520 | \u25ab"),

--- a/test/test_tokeniser.py
+++ b/test/test_tokeniser.py
@@ -123,6 +123,7 @@ def test_int_repeated():
     assert tokens("1..") == [Token("Number", "1", 0), Token("Repeated", "..", 1)]
     assert tokens("1. .") == [Token("Number", "1.", 0), Token("Dot", ".", 3)]
 
+
 def test_integeral():
     assert tokens("\u222B x \uf74c y") == [
         Token("Integral", "\u222B", 0),

--- a/test/test_tokeniser.py
+++ b/test/test_tokeniser.py
@@ -123,12 +123,11 @@ def test_int_repeated():
     assert tokens("1..") == [Token("Number", "1", 0), Token("Repeated", "..", 1)]
     assert tokens("1. .") == [Token("Number", "1.", 0), Token("Dot", ".", 3)]
 
-
 def test_integeral():
-    assert tokens("\u222B x \U0001D451 y") == [
+    assert tokens("\u222B x \uf74c y") == [
         Token("Integral", "\u222B", 0),
         Token("Symbol", "x", 2),
-        Token("DifferentialD", "\U0001D451", 4),
+        Token("DifferentialD", "\uf74c", 4),
         Token("Symbol", "y", 6),
     ]
 

--- a/test/test_translation_regressions.py
+++ b/test/test_translation_regressions.py
@@ -11,7 +11,7 @@ def check_translation_regression(c: str, expected_translation: str):
 
 
 def test_translation_regressions():
-    check_translation_regression("DifferentialD", "𝑑")
+    check_translation_regression("DifferentialD", "\U0001D451")
     check_translation_regression("PartialD", "\u2202")
     check_translation_regression("Uranus", "\u2645")
     check_translation_regression("WeierstrassP", "\u2118")


### PR DESCRIPTION
This PR adds the table of amstex symbols, and fixes #42 