### PR TITLE
Comment and (type) annotate "prescanning" module.

### DIFF
--- a/mathics_scanner/prescanner.py
+++ b/mathics_scanner/prescanner.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+Module for "prescanning". Right now this just means replacing
+character escape sequences.
+"""
+
+from typing import Callable
 
 from mathics_scanner.characters import named_characters
 from mathics_scanner.errors import ScanError, IncompleteSyntaxError
@@ -6,28 +12,31 @@ from mathics_scanner.errors import ScanError, IncompleteSyntaxError
 
 class Prescanner(object):
     r"""
-    Converts:
-        character codes to characters:
+    A Class for converting escape sequences:
+        Character codes to characters:
             \.7A -> z
+            \.004a -> J
             \:004a -> J
             \|01D451  -> \U0001D451
             \041 -> !
-        unicode longnames to characters:
+        Named Characters to Unicode:
             \[Theta] -> \u03B8
-        escape sequences:
+        ASCII escape sequence:
             \n -> literal \n
 
-    Also reports trailing \ characters as incomplete.
-
-    PreScanner works by breaking the partitioning code into stubs.
+    Trailing backslash characters (\) are reported incomplete.
     """
 
-    def __init__(self, feeder):
-        self.feeder = feeder  # returns more code when asked
+    def __init__(self, feeder: Callable):
+        # feeder is a function that returns the next line of the Mathics input
+        self.feeder = feeder
         self.code = feeder.feed()  # input code
         self.pos = 0  # current position within code
 
-    def feed(self):
+    def feed(self) -> str:
+        """
+        Return the next line of Mathics input
+        """
         return self.feeder.feed()
 
     def incomplete(self):
@@ -37,89 +46,142 @@ class Prescanner(object):
             raise IncompleteSyntaxError()
         self.code += line
 
-    def scan(self):
-        # main loop
-        self.stubs = []  # stubs of code to be joined
-        self.start = self.pos  # start of current stub
+    def scan(self) -> str:
+        """
+        Replace escape sequences in self.code. The replacement string is returned.
+        Note: self.code is not modified.
+        """
+
+        line_fragments = (
+            []
+        )  # line fragments to be joined before returning from this method.
+        self.fragment_start = (
+            self.pos
+        )  # start position of line fragment under consideration
+
+        def start_new_fragment(pos: int) -> None:
+            """
+            Update position markers to start a new line fragment at ``pos``.
+            """
+            self.pos = pos
+            self.fragment_start = pos
+
+        def try_parse_base(start_shift: int, end_shift: int, base: int) -> None:
+            """
+            See if characters self.pos+start_shift .. self.pos+end shift
+            can be converted to an integer in base  ``base``.
+
+            If so, we append, the characters before the escape sequence without the
+            escaping characters like ``\.`` or ``\:``.
+
+            We also append the converted integer to ``line_fragments``, and updated
+            position cursors for a new line fragment.
+
+            However, if the conversion fails, error messages are issued and nothing
+            is updated
+            """
+            start, end = self.pos + start_shift, self.pos + end_shift
+            result = None
+            if end <= len(self.code):
+                text = self.code[start:end]
+                try:
+                    result = int(text, base)
+                except ValueError:
+                    pass  # result remains None
+            if result is None:
+                last = end - start
+                if last == 2:
+                    self.feeder.message("Syntax", "sntoct2")
+                elif last == 3:
+                    self.feeder.message("Syntax", "sntoct1")
+                elif last == 4:
+                    self.feeder.message("Syntax", "snthex")
+                else:
+                    raise ValueError()
+                self.feeder.message(
+                    "Syntax", "sntxb", self.code[self.pos :].rstrip("\n")
+                )
+                raise ScanError()
+            line_fragments.append(self.code[start : self.pos])
+            line_fragments.append(chr(result))
+
+            # Set up a new line fragment for the next time we are called.
+            start_new_fragment(end)
+
+        def try_parse_named_character(start_shift: int):
+            """Before calling we have matched "\[".  Scan to the remaining "]" and
+            try to match what is found in-between with a known named
+            character, e.g. "Theta".  If we can match this, we store
+            the unicode character equivalent in ``line_fragments``.
+            If we can't find a named character, error messages are
+            issued and we leave ``line_fragments`` untouched.
+            """
+            i = self.pos + start_shift
+            while True:
+                if i == len(self.code):
+                    self.incomplete()
+                if self.code[i] == "]":
+                    break
+                i += 1
+
+            named_character = self.code[self.pos + start_shift : i]
+            if named_character.isalpha():
+                char = named_characters.get(named_character)
+                if char is None:
+                    self.feeder.message("Syntax", "sntufn", named_character)
+                    # stay in same line fragment
+                else:
+                    line_fragments.append(self.code[self.fragment_start : self.pos])
+                    line_fragments.append(char)
+                    start_new_fragment(i + 1)
+
+            # Stay in same line fragment, but advance the cursor position.
+            self.pos = i + 1
+
+        # In the following loop, we look for and replace escape
+        # sequences. The current character under consideration is at
+        # self.code[self.pos].  When an escape sequence is found at
+        # that position, the previous line_fragment is extracted and
+        # stored in ``line_fragments``. The start-position marker for the
+        # next line_fragment is started and self.pos is updated.
+
         while self.pos < len(self.code):
             if self.code[self.pos] == "\\":
+                # Look for and handle an escape sequence.
                 if self.pos + 1 == len(self.code):
                     self.incomplete()
                 c = self.code[self.pos + 1]
                 if c == "|":
-                    self.try_parse_base(2, 8, 16)
+                    try_parse_base(2, 8, 16)
                 if c == ".":
-                    self.try_parse_base(2, 4, 16)
+                    # See if we have a two-digit hexadecimal number.
+                    try_parse_base(2, 4, 16)
                 elif c == ":":
-                    self.try_parse_base(2, 6, 16)
+                    # See if we have a four-digit hexadecimal number.
+                    try_parse_base(2, 6, 16)
                 elif c == "[":
-                    self.try_parse_longname(2)
+                    try_parse_named_character(2)
                 elif c in "01234567":
-                    self.try_parse_base(1, 4, 8)
+                    # See if we have an octal number.
+                    try_parse_base(1, 4, 8)
                 elif c == "\n":
                     if self.pos + 2 == len(self.code):
                         self.incomplete()
-                    self.stubs.append(self.code[self.start : self.pos])
-                    self.newstub(self.pos + 2)
+                    self.line_fragments.append(
+                        self.code[self.fragment_start : self.pos]
+                    )
+                    start_new_fragment(self.pos + 2)
                 else:
-                    # Two backslashes in succession indicates a single backslash character,
-                    # rather than an escape sequence which also starts with a backslash.
-                    #  Advance the scanning cursor (self.pos) over both backslashes.
+                    # Two backslashes in succession indicates a single backslash character.
+                    # Advance the scanning cursor (self.pos) over both backslashes.
                     # Also, Python's backslash escape mechanism turns the two backslashes
                     # into one in length calculations.
                     self.pos += 2
             else:
                 self.pos += 1
-        self.stubs.append(self.code[self.start :])  # final stub
-        # reduce
-        return "".join(self.stubs)
 
-    def newstub(self, pos: int) -> None:
-        self.pos = pos
-        self.start = pos
+        # Close out final line fragment
+        line_fragments.append(self.code[self.fragment_start :])
 
-    def try_parse_base(self, start_shift: int, end_shift: int, base: int) -> None:
-        start, end = self.pos + start_shift, self.pos + end_shift
-        result = None
-        if end <= len(self.code):
-            text = self.code[start:end]
-            try:
-                result = int(text, base)
-            except ValueError:
-                pass  # result remains None
-        if result is None:
-            last = end - start
-            if last == 2:
-                self.feeder.message("Syntax", "sntoct2")
-            elif last == 3:
-                self.feeder.message("Syntax", "sntoct1")
-            elif last == 4:
-                self.feeder.message("Syntax", "snthex")
-            else:
-                raise ValueError()
-            self.feeder.message("Syntax", "sntxb", self.code[self.pos :].rstrip("\n"))
-            raise ScanError()
-        self.stubs.append(self.code[self.start : self.pos])
-        self.stubs.append(chr(result))
-        self.newstub(end)
-
-    def try_parse_longname(self, start_shift):
-        i = self.pos + start_shift
-        while True:
-            if i == len(self.code):
-                self.incomplete()
-            if self.code[i] == "]":
-                break
-            i += 1
-
-        longname = self.code[self.pos + start_shift : i]
-        if longname.isalpha():
-            char = named_characters.get(longname)
-            if char is None:
-                self.feeder.message("Syntax", "sntufn", longname)
-                pass  # stay in same stub
-            else:
-                self.stubs.append(self.code[self.start : self.pos])
-                self.stubs.append(char)
-                self.newstub(i + 1)
-        self.pos = i + 1  # stay in same stub but skip ahead
+        # produce and return the replacement string.
+        return "".join(line_fragments)

--- a/mathics_scanner/prescanner.py
+++ b/mathics_scanner/prescanner.py
@@ -52,12 +52,11 @@ class Prescanner(object):
         Note: self.code is not modified.
         """
 
-        line_fragments = (
-            []
-        )  # line fragments to be joined before returning from this method.
-        self.fragment_start = (
-            self.pos
-        )  # start position of line fragment under consideration
+        # Line fragments to be joined before returning from this method.
+        line_fragments = []
+
+        # Fragment start position of line fragment under consideration.
+        self.fragment_start = self.pos
 
         def start_new_fragment(pos: int) -> None:
             """
@@ -71,14 +70,14 @@ class Prescanner(object):
             See if characters self.pos+start_shift .. self.pos+end shift
             can be converted to an integer in base  ``base``.
 
-            If so, we append, the characters before the escape sequence without the
+            If so, we append the characters before the escape sequence without the
             escaping characters like ``\.`` or ``\:``.
 
-            We also append the converted integer to ``line_fragments``, and updated
+            We also append the converted integer to ``line_fragments``, and update
             position cursors for a new line fragment.
 
-            However, if the conversion fails, error messages are issued and nothing
-            is updated
+            However, if the conversion fails, then error messages are
+            issued and nothing is updated
             """
             start, end = self.pos + start_shift, self.pos + end_shift
             result = None
@@ -102,6 +101,10 @@ class Prescanner(object):
                     "Syntax", "sntxb", self.code[self.pos :].rstrip("\n")
                 )
                 raise ScanError()
+
+            # Add text from prior line fragment as well
+            # as the escape sequence, a character, from the escape sequence
+            # that was just matched.
             line_fragments.append(self.code[start : self.pos])
             line_fragments.append(chr(result))
 
@@ -131,6 +134,9 @@ class Prescanner(object):
                     self.feeder.message("Syntax", "sntufn", named_character)
                     # stay in same line fragment
                 else:
+                    # Add text from prior line fragment as well
+                    # as the escape sequence, a character, from the escape sequence
+                    # just matched.
                     line_fragments.append(self.code[self.fragment_start : self.pos])
                     line_fragments.append(char)
                     start_new_fragment(i + 1)
@@ -180,7 +186,7 @@ class Prescanner(object):
             else:
                 self.pos += 1
 
-        # Close out final line fragment
+        # Add the final line fragment.
         line_fragments.append(self.code[self.fragment_start :])
 
         # produce and return the replacement string.

--- a/mathics_scanner/prescanner.py
+++ b/mathics_scanner/prescanner.py
@@ -46,7 +46,7 @@ class Prescanner(object):
             raise IncompleteSyntaxError()
         self.code += line
 
-    def scan(self) -> str:
+    def replace_escape_sequences(self) -> str:
         """
         Replace escape sequences in self.code. The replacement string is returned.
         Note: self.code is not modified.

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -357,7 +357,7 @@ class Tokeniser(object):
         self.pos = 0
         self.feeder = feeder
         self.prescanner = Prescanner(feeder)
-        self.code = self.prescanner.scan()
+        self.code = self.prescanner.replace_escape_sequences()
         self._change_mode("expr")
 
     def _change_mode(self, mode):
@@ -371,7 +371,7 @@ class Tokeniser(object):
     def incomplete(self):
         "Get more code from the prescanner and continue."
         self.prescanner.incomplete()
-        self.code += self.prescanner.scan()
+        self.code += self.prescanner.replace_escape_sequences()
 
     def sntx_message(self, pos=None):
         """Send a message to the feeder."""

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -367,7 +367,7 @@ class Tokeniser(object):
         self.mode = mode
         self.tokens, self.token_indices = self.modes[mode]
 
-    # TODO: Rename this to something that remotetly makes sense?
+    # TODO: Rename this to something that remotely makes sense?
     def incomplete(self):
         "Get more code from the prescanner and continue."
         self.prescanner.incomplete()

--- a/test/test_prescanner.py
+++ b/test/test_prescanner.py
@@ -6,100 +6,100 @@ from mathics_scanner.prescanner import Prescanner
 from mathics_scanner.feed import SingleLineFeeder
 
 
-def replace_escape_sequences(code):
-    prescanner = Prescanner(SingleLineFeeder(code))
+def replace_escape_sequences(mathics_text: str):
+    prescanner = Prescanner(SingleLineFeeder(mathics_text))
     return prescanner.replace_escape_sequences()
 
 
-def invalid(code):
+def assert_invalid(mathics_text: str):
     with pytest.raises(ScanError):
-        replace_escape_sequences(code)
+        replace_escape_sequences(mathics_text)
 
 
-def incomplete(code):
+def assert_incomplete(mathics_text: str):
     with pytest.raises(IncompleteSyntaxError):
-        replace_escape_sequences(code)
+        replace_escape_sequences(mathics_text)
 
 
-def equal(code, result):
-    assert replace_escape_sequences(code) == result
+def assert_equal(mathics_text: str, result: str):
+    assert replace_escape_sequences(mathics_text) == result
 
 
-def equal_length(code, length):
-    assert len(replace_escape_sequences(code)) == length
+def assert_equal_length(mathics_text: str, length):
+    assert len(replace_escape_sequences(mathics_text)) == length
 
 
 def test_named_characters():
-    equal(r"\[Theta]", "\u03B8")
-    equal(r"\[CapitalPi]", "\u03A0")
-    equal(r"\[Fake]", r"\[Fake]")
-    equal("z \\[Conjugate]", "z \uF3C8")
-    equal("z \\[Integral]", "z \u222b")
-    equal("z \\\\[Integral]", "z \\\\[Integral]")
-    equal("z \\\\\\[Integral]", "z \\\\\u222b")
-    equal("abc\\\\", "abc\\\\")
+    assert_equal(r"\[Theta]", "\u03B8")
+    assert_equal(r"\[CapitalPi]", "\u03A0")
+    assert_equal(r"\[Fake]", r"\[Fake]")
+    assert_equal("z \\[Conjugate]", "z \uF3C8")
+    assert_equal("z \\[Integral]", "z \u222b")
+    assert_equal("z \\\\[Integral]", "z \\\\[Integral]")
+    assert_equal("z \\\\\\[Integral]", "z \\\\\u222b")
+    assert_equal("abc\\\\", "abc\\\\")
 
 
 def test_text_lengths():
-    equal_length(r'"\[Integral]"', 3)
+    assert_equal_length(r'"\[Integral]"', 3)
     # Prescanner keep both slashes and quotes.
     # The tokenizer brings \\ into \ if it appears
     # inside a string.
-    equal_length(r'"\\[Integral]"', 14)
+    assert_equal_length(r'"\\[Integral]"', 14)
 
 
 def test_oct():
-    equal(r"\051", ")")
+    assert_equal(r"\051", ")")
 
 
 def test_hex_dot():
-    equal(r"\.30", "0")
+    assert_equal(r"\.30", "0")
 
 
 def test_hex_colon():
-    equal(r"\:0030", "0")
-    equal(r"\:03B8", "\u03B8")
-    equal(r"\:03b8", "\u03B8")
+    assert_equal(r"\:0030", "0")
+    assert_equal(r"\:03B8", "\u03B8")
+    assert_equal(r"\:03b8", "\u03B8")
 
 
 def test_hex_vbar():
-    equal(r"\|01D451", "\U0001D451")
+    assert_equal(r"\|01D451", "\U0001D451")
 
 
 def test_incomplete():
-    incomplete(r"\[")
-    incomplete(r"\[Theta")
+    assert_incomplete(r"\[")
+    assert_incomplete(r"\[Theta")
 
 
-def test_invalid_oct():
-    invalid(r"\093")
-    invalid(r"\01")
+def test_invalid_octal():
+    assert_invalid(r"\093")
+    assert_invalid(r"\01")
 
 
 def test_invalid_colon():
-    invalid(r"\:")
-    invalid(r"\:A")
-    invalid(r"\:01")
-    invalid(r"\:A1")
-    invalid(r"\:ak")
-    invalid(r"\:A10")
-    invalid(r"\:a1g")
-    invalid(r"\:A1g9")
-    invalid(r"\:01-2")
+    assert_invalid(r"\:")
+    assert_invalid(r"\:A")
+    assert_invalid(r"\:01")
+    assert_invalid(r"\:A1")
+    assert_invalid(r"\:ak")
+    assert_invalid(r"\:A10")
+    assert_invalid(r"\:a1g")
+    assert_invalid(r"\:A1g9")
+    assert_invalid(r"\:01-2")
 
 
 def test_invalid_dot():
-    invalid(r"\.")
-    invalid(r"\.0")
+    assert_invalid(r"\.")
+    assert_invalid(r"\.0")
 
 
 def test_combined():
-    equal(r"\:03B8\[Theta]\.30\052", "\u03B8\u03B80*")
+    assert_equal(r"\:03B8\[Theta]\.30\052", "\u03B8\u03B80*")
 
 
 def test_nested():
-    equal(r"\[Thet\141]", r"\[Thet\141]")
+    assert_equal(r"\[Thet\141]", r"\[Thet\141]")
 
 
 def test_trailing_backslash():
-    incomplete("x \\")
+    assert_incomplete("x \\")

--- a/test/test_prescanner.py
+++ b/test/test_prescanner.py
@@ -24,7 +24,7 @@ class PrescannerTest(unittest.TestCase):
     def equal_length(self, code, length):
         assert len(self.prescan(code)) == length
 
-    def test_longnames(self):
+    def test_named_characters(self):
         self.equal(r"\[Theta]", "\u03B8")
         self.equal(r"\[CapitalPi]", "\u03A0")
         self.equal(r"\[Fake]", r"\[Fake]")

--- a/test/test_prescanner.py
+++ b/test/test_prescanner.py
@@ -1,88 +1,105 @@
 # -*- coding: utf-8 -*-
-
-import unittest
+import pytest
 
 from mathics_scanner import IncompleteSyntaxError, ScanError
 from mathics_scanner.prescanner import Prescanner
 from mathics_scanner.feed import SingleLineFeeder
 
 
-class PrescannerTest(unittest.TestCase):
-    def prescan(self, code):
-        prescanner = Prescanner(SingleLineFeeder(code))
-        return prescanner.scan()
+def replace_escape_sequences(code):
+    prescanner = Prescanner(SingleLineFeeder(code))
+    return prescanner.replace_escape_sequences()
 
-    def invalid(self, code):
-        self.assertRaises(ScanError, self.prescan, code)
 
-    def incomplete(self, code):
-        self.assertRaises(IncompleteSyntaxError, self.prescan, code)
+def invalid(code):
+    with pytest.raises(ScanError):
+        replace_escape_sequences(code)
 
-    def equal(self, code, result):
-        assert self.prescan(code) == result
 
-    def equal_length(self, code, length):
-        assert len(self.prescan(code)) == length
+def incomplete(code):
+    with pytest.raises(IncompleteSyntaxError):
+        replace_escape_sequences(code)
 
-    def test_named_characters(self):
-        self.equal(r"\[Theta]", "\u03B8")
-        self.equal(r"\[CapitalPi]", "\u03A0")
-        self.equal(r"\[Fake]", r"\[Fake]")
-        self.equal("z \\[Conjugate]", "z \uF3C8")
-        self.equal("z \\[Integral]", "z \u222b")
-        self.equal("z \\\\[Integral]", "z \\\\[Integral]")
-        self.equal("z \\\\\\[Integral]", "z \\\\\u222b")
-        self.equal("abc\\\\", "abc\\\\")
 
-    def test_lengths(self):
-        self.equal_length(r'"\[Integral]"', 3)
-        # Prescanner keep both slashes and quotes.
-        # The tokenizer brings \\ into \ if it appears
-        # inside a string.
-        self.equal_length(r'"\\[Integral]"', 14)
+def equal(code, result):
+    assert replace_escape_sequences(code) == result
 
-    def test_oct(self):
-        self.equal(r"\051", ")")
 
-    def test_hex_dot(self):
-        self.equal(r"\.30", "0")
+def equal_length(code, length):
+    assert len(replace_escape_sequences(code)) == length
 
-    def test_hex_colon(self):
-        self.equal(r"\:0030", "0")
-        self.equal(r"\:03B8", "\u03B8")
-        self.equal(r"\:03b8", "\u03B8")
 
-    def test_hex_vbar(self):
-        self.equal(r"\|01D451", "\U0001D451")
+def test_named_characters():
+    equal(r"\[Theta]", "\u03B8")
+    equal(r"\[CapitalPi]", "\u03A0")
+    equal(r"\[Fake]", r"\[Fake]")
+    equal("z \\[Conjugate]", "z \uF3C8")
+    equal("z \\[Integral]", "z \u222b")
+    equal("z \\\\[Integral]", "z \\\\[Integral]")
+    equal("z \\\\\\[Integral]", "z \\\\\u222b")
+    equal("abc\\\\", "abc\\\\")
 
-    def test_incomplete(self):
-        self.incomplete(r"\[")
-        self.incomplete(r"\[Theta")
 
-    def test_invalid_oct(self):
-        self.invalid(r"\093")
-        self.invalid(r"\01")
+def test_text_lengths():
+    equal_length(r'"\[Integral]"', 3)
+    # Prescanner keep both slashes and quotes.
+    # The tokenizer brings \\ into \ if it appears
+    # inside a string.
+    equal_length(r'"\\[Integral]"', 14)
 
-    def test_invalid_colon(self):
-        self.invalid(r"\:")
-        self.invalid(r"\:A")
-        self.invalid(r"\:01")
-        self.invalid(r"\:A1")
-        self.invalid(r"\:ak")
-        self.invalid(r"\:A10")
-        self.invalid(r"\:a1g")
-        self.invalid(r"\:A1g9")
-        self.invalid(r"\:01-2")
 
-    def test_invalid_dot(self):
-        self.invalid(r"\.")
-        self.invalid(r"\.0")
+def test_oct():
+    equal(r"\051", ")")
 
-    def test_combined(self):
-        self.equal(r"\:03B8\[Theta]\.30\052", "\u03B8\u03B80*")
 
-    def test_nested(self):
-        self.equal(r"\[Thet\141]", r"\[Thet\141]")
+def test_hex_dot():
+    equal(r"\.30", "0")
 
-    def test_trailing_backslash(self):
-        self.incomplete("x \\")
+
+def test_hex_colon():
+    equal(r"\:0030", "0")
+    equal(r"\:03B8", "\u03B8")
+    equal(r"\:03b8", "\u03B8")
+
+
+def test_hex_vbar():
+    equal(r"\|01D451", "\U0001D451")
+
+
+def test_incomplete():
+    incomplete(r"\[")
+    incomplete(r"\[Theta")
+
+
+def test_invalid_oct():
+    invalid(r"\093")
+    invalid(r"\01")
+
+
+def test_invalid_colon():
+    invalid(r"\:")
+    invalid(r"\:A")
+    invalid(r"\:01")
+    invalid(r"\:A1")
+    invalid(r"\:ak")
+    invalid(r"\:A10")
+    invalid(r"\:a1g")
+    invalid(r"\:A1g9")
+    invalid(r"\:01-2")
+
+
+def test_invalid_dot():
+    invalid(r"\.")
+    invalid(r"\.0")
+
+
+def test_combined():
+    equal(r"\:03B8\[Theta]\.30\052", "\u03B8\u03B80*")
+
+
+def test_nested():
+    equal(r"\[Thet\141]", r"\[Thet\141]")
+
+
+def test_trailing_backslash():
+    incomplete("x \\")


### PR DESCRIPTION
Reduce the use of "self" variables as for local temporary variables. Make private the private functions (try_xxx()).

I don't know why something like "escape sequence" replacement has to be over bloated into the less meaningful and vague "prescanning". Maybe one day it will do something fancier. 