### PR TITLE
Amstext+wl unicode convert

### DIFF
--- a/mathics_scanner/characters.py
+++ b/mathics_scanner/characters.py
@@ -47,7 +47,7 @@ _wl_to_ascii_re = re.compile(_data.get("wl-to-ascii-re", ""))
 _wl_to_amstex = _data.get("wl-to-amstex", None)
 
 # Conversion from WL to unicode
-_wl_to_unicode = _data.get("wl-to-unicode-dict", {})
+_wl_to_unicode = _data.get("wl-to-unicode-dict", _data.get("wl_to_ascii"))
 _wl_to_unicode_re = re.compile(_data.get("wl-to-unicode-re", ""))
 
 # Conversion from unicode to WL
@@ -61,6 +61,7 @@ named_characters = _data.get("named-characters", {})
 aliased_characters = _data.get("aliased-characters", {})
 
 
+# Deprecated
 def replace_wl_with_plain_text(wl_input: str, use_unicode=True) -> str:
     """
     The Wolfram Language uses specific Unicode characters to represent Wolfram
@@ -81,9 +82,12 @@ def replace_wl_with_plain_text(wl_input: str, use_unicode=True) -> str:
     r = _wl_to_unicode_re if use_unicode else _wl_to_ascii_re
     d = _wl_to_unicode if use_unicode else _wl_to_ascii
 
-    return r.sub(lambda m: d[m.group(0)], wl_input)
+    # The below on when use_unicode is False will sometime test on "ascii" twice.
+    # But this routine should be deprecated.
+    return r.sub(lambda m: d.get(m.group(0), _wl_to_ascii.get(m.group(0))), wl_input)
 
 
+# Deprecated
 def replace_unicode_with_wl(unicode_input: str) -> str:
     """
     The Wolfram Language uses specific Unicode characters to represent Wolfram

--- a/mathics_scanner/characters.py
+++ b/mathics_scanner/characters.py
@@ -43,6 +43,9 @@ _letterlikes = _data.get("letterlikes", {})
 _wl_to_ascii = _data.get("wl-to-ascii-dict", {})
 _wl_to_ascii_re = re.compile(_data.get("wl-to-ascii-re", ""))
 
+# AMS LaTeX replacements
+_wl_to_amstex = _data.get("wl-to-amstex", None)
+
 # Conversion from WL to unicode
 _wl_to_unicode = _data.get("wl-to-unicode-dict", {})
 _wl_to_unicode_re = re.compile(_data.get("wl-to-unicode-re", ""))

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -62,6 +62,7 @@ AAcute:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH ACUTE
   wl-unicode: "\xE1"
   wl-unicode-name: LATIN SMALL LETTER A WITH ACUTE
+
 ABar:
   amslatex: "\\={a}"
   esc-alias: a-
@@ -71,6 +72,7 @@ ABar:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH MACRON
   wl-unicode: "\u0101"
   wl-unicode-name: LATIN SMALL LETTER A WITH MACRON
+
 ACup:
   amslatex: "\\u{a}"
   esc-alias: au
@@ -95,6 +97,7 @@ ADoubleDot:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH DIAERESIS
   wl-unicode: "\xE4"
   wl-unicode-name: LATIN SMALL LETTER A WITH DIAERESIS
+
 AE:
   esc-alias: ae
   has-unicode-inverse: false
@@ -103,6 +106,7 @@ AE:
   unicode-equivalent-name: LATIN SMALL LETTER AE
   wl-unicode: "\xE6"
   wl-unicode-name: LATIN SMALL LETTER AE
+
 AGrave:
   amslatex: "\\`{a}"
   esc-alias: a`
@@ -112,6 +116,7 @@ AGrave:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH GRAVE
   wl-unicode: "\xE0"
   wl-unicode-name: LATIN SMALL LETTER A WITH GRAVE
+
 AHat:
   esc-alias: a^
   has-unicode-inverse: false
@@ -162,6 +167,7 @@ ARing:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH RING ABOVE
   wl-unicode: "\xE5"
   wl-unicode-name: LATIN SMALL LETTER A WITH RING ABOVE
+
 ATilde:
   esc-alias: a~
   has-unicode-inverse: false
@@ -170,6 +176,7 @@ ATilde:
   unicode-equivalent-name: LATIN SMALL LETTER A WITH TILDE
   wl-unicode: "\xE3"
   wl-unicode-name: LATIN SMALL LETTER A WITH TILDE
+
 Aleph:
   amslatex: "\\aleph"
   esc-alias: al
@@ -194,11 +201,13 @@ AliasIndicator:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF768"
+
 AlignmentMarker:
   esc-alias: am
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF760"
+
 Alpha:
   amslatex: "\\alpha"
   esc-alias: a
@@ -208,6 +217,7 @@ Alpha:
   unicode-equivalent-name: GREEK SMALL LETTER ALPHA
   wl-unicode: "\u03B1"
   wl-unicode-name: GREEK SMALL LETTER ALPHA
+
 AltKey:
   esc-alias: alt
   has-unicode-inverse: false
@@ -225,6 +235,7 @@ And:
   unicode-equivalent-name: LOGICAL AND
   wl-unicode: "\u2227"
   wl-unicode-name: LOGICAL AND
+
 Angle:
   amslatex: "\\angle"
   has-unicode-inverse: false
@@ -233,6 +244,7 @@ Angle:
   unicode-equivalent-name: ANGLE
   wl-unicode: "\u2220"
   wl-unicode-name: ANGLE
+
 Angstrom:
   amslatex: "\\Angstrom"
   esc-alias: Ang
@@ -242,6 +254,7 @@ Angstrom:
   unicode-equivalent-name: ANGSTROM SIGN
   wl-unicode: "\u212B"
   wl-unicode-name: ANGSTROM SIGN
+
 AquariusSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -249,6 +262,7 @@ AquariusSign:
   unicode-equivalent-name: AQUARIUS
   wl-unicode: "\u2652"
   wl-unicode-name: AQUARIUS
+
 AriesSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -256,6 +270,7 @@ AriesSign:
   unicode-equivalent-name: ARIES
   wl-unicode: "\u2648"
   wl-unicode-name: ARIES
+
 AscendingEllipsis:
   has-unicode-inverse: false
   is-letter-like: false
@@ -263,26 +278,32 @@ AscendingEllipsis:
   unicode-equivalent-name: UP RIGHT DIAGONAL ELLIPSIS
   wl-unicode: "\u22F0"
   wl-unicode-name: UP RIGHT DIAGONAL ELLIPSIS
+
 AutoLeftMatch:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3A8"
+
 AutoOperand:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3AE"
+
 AutoPlaceholder:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3A4"
+
 AutoRightMatch:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3A9"
+
 AutoSpace:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3AD"
+
 Backslash:
   esc-alias: \
   has-unicode-inverse: false
@@ -291,6 +312,7 @@ Backslash:
   unicode-equivalent-name: SET MINUS
   wl-unicode: "\u2216"
   wl-unicode-name: SET MINUS
+
 BeamedEighthNote:
   has-unicode-inverse: false
   is-letter-like: false
@@ -298,6 +320,7 @@ BeamedEighthNote:
   unicode-equivalent-name: BEAMED EIGHTH NOTES
   wl-unicode: "\u266B"
   wl-unicode-name: BEAMED EIGHTH NOTES
+
 BeamedSixteenthNote:
   has-unicode-inverse: false
   is-letter-like: false
@@ -305,6 +328,7 @@ BeamedSixteenthNote:
   unicode-equivalent-name: BEAMED SIXTEENTH NOTES
   wl-unicode: "\u266C"
   wl-unicode-name: BEAMED SIXTEENTH NOTES
+
 Because:
   has-unicode-inverse: false
   is-letter-like: false
@@ -313,6 +337,7 @@ Because:
   unicode-equivalent-name: BECAUSE
   wl-unicode: "\u2235"
   wl-unicode-name: BECAUSE
+
 Bet:
   amslatex: "\\beth"
   esc-alias: be
@@ -322,6 +347,7 @@ Bet:
   unicode-equivalent-name: BET SYMBOL
   wl-unicode: "\u2136"
   wl-unicode-name: BET SYMBOL
+
 Beta:
   amslatex: "\\beta"
   esc-alias: b
@@ -331,6 +357,7 @@ Beta:
   unicode-equivalent-name: GREEK SMALL LETTER BETA
   wl-unicode: "\u03B2"
   wl-unicode-name: GREEK SMALL LETTER BETA
+
 BlackBishop:
   has-unicode-inverse: false
   is-letter-like: false
@@ -338,6 +365,7 @@ BlackBishop:
   unicode-equivalent-name: BLACK CHESS BISHOP
   wl-unicode: "\u265D"
   wl-unicode-name: BLACK CHESS BISHOP
+
 BlackKing:
   has-unicode-inverse: false
   is-letter-like: false
@@ -345,6 +373,7 @@ BlackKing:
   unicode-equivalent-name: BLACK CHESS KING
   wl-unicode: "\u265A"
   wl-unicode-name: BLACK CHESS KING
+
 BlackKnight:
   has-unicode-inverse: false
   is-letter-like: false
@@ -352,6 +381,7 @@ BlackKnight:
   unicode-equivalent-name: BLACK CHESS KNIGHT
   wl-unicode: "\u265E"
   wl-unicode-name: BLACK CHESS KNIGHT
+
 BlackPawn:
   has-unicode-inverse: false
   is-letter-like: false
@@ -359,6 +389,7 @@ BlackPawn:
   unicode-equivalent-name: BLACK CHESS PAWN
   wl-unicode: "\u265F"
   wl-unicode-name: BLACK CHESS PAWN
+
 BlackQueen:
   has-unicode-inverse: false
   is-letter-like: false
@@ -366,6 +397,7 @@ BlackQueen:
   unicode-equivalent-name: BLACK CHESS QUEEN
   wl-unicode: "\u265B"
   wl-unicode-name: BLACK CHESS QUEEN
+
 BlackRook:
   has-unicode-inverse: false
   is-letter-like: false
@@ -373,21 +405,25 @@ BlackRook:
   unicode-equivalent-name: BLACK CHESS ROOK
   wl-unicode: "\u265C"
   wl-unicode-name: BLACK CHESS ROOK
+
 Blank:
   ascii: "_"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Blank
+
 BlankNullSequence:
   ascii: "___"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: BlankNullSequence
+
 BlankSequence:
   ascii: "__"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: BlankSequence
+
 Breve:
   esc-alias: bv
   has-unicode-inverse: false
@@ -396,6 +432,7 @@ Breve:
   unicode-equivalent-name: BREVE
   wl-unicode: "\u02D8"
   wl-unicode-name: BREVE
+
 Bullet:
   amslatex: "\\bullet"
   esc-alias: bu
@@ -405,6 +442,7 @@ Bullet:
   unicode-equivalent-name: BULLET
   wl-unicode: "\u2022"
   wl-unicode-name: BULLET
+
 CAcute:
   amslatex: "\\'{c}"
   esc-alias: c'
@@ -414,6 +452,7 @@ CAcute:
   unicode-equivalent-name: LATIN SMALL LETTER C WITH ACUTE
   wl-unicode: "\u0107"
   wl-unicode-name: LATIN SMALL LETTER C WITH ACUTE
+
 CCedilla:
   amslatex: "\\c{c}"
   esc-alias: c
@@ -423,6 +462,7 @@ CCedilla:
   unicode-equivalent-name: LATIN SMALL LETTER C WITH CEDILLA
   wl-unicode: "\xE7"
   wl-unicode-name: LATIN SMALL LETTER C WITH CEDILLA
+
 CHacek:
   amslatex: "\\v{c}"
   esc-alias: cv
@@ -432,6 +472,7 @@ CHacek:
   unicode-equivalent-name: LATIN SMALL LETTER C WITH CARON
   wl-unicode: "\u010D"
   wl-unicode-name: LATIN SMALL LETTER C WITH CARON
+
 CancerSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -439,6 +480,7 @@ CancerSign:
   unicode-equivalent-name: CANCER
   wl-unicode: "\u264B"
   wl-unicode-name: CANCER
+
 Cap:
   amslatex: "\\cap"
   has-unicode-inverse: false
@@ -447,6 +489,7 @@ Cap:
   unicode-equivalent-name: FROWN
   wl-unicode: "\u2322"
   wl-unicode-name: FROWN
+
 CapitalAAcute:
   amslatex: "\\'{A}"
   esc-alias: A'
@@ -456,6 +499,7 @@ CapitalAAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH ACUTE
   wl-unicode: "\xC1"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH ACUTE
+
 CapitalABar:
   amslatex: "\\={A}"
   esc-alias: A-
@@ -465,6 +509,7 @@ CapitalABar:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH MACRON
   wl-unicode: "\u0100"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH MACRON
+
 CapitalACup:
   amslatex: "\\u{A}"
   esc-alias: Au
@@ -474,6 +519,7 @@ CapitalACup:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH BREVE
   wl-unicode: "\u0102"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH BREVE
+
 CapitalADoubleDot:
   esc-alias: A"
   has-unicode-inverse: true
@@ -482,6 +528,7 @@ CapitalADoubleDot:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH DIAERESIS
   wl-unicode: "\xC4"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH DIAERESIS
+
 CapitalAE:
   esc-alias: AE
   has-unicode-inverse: true
@@ -490,6 +537,7 @@ CapitalAE:
   unicode-equivalent-name: LATIN CAPITAL LETTER AE
   wl-unicode: "\xC6"
   wl-unicode-name: LATIN CAPITAL LETTER AE
+
 CapitalAGrave:
   amslatex: "\\`{A}"
   esc-alias: A`
@@ -499,6 +547,7 @@ CapitalAGrave:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH GRAVE
   wl-unicode: "\xC0"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH GRAVE
+
 CapitalAHat:
   esc-alias: A^
   has-unicode-inverse: false
@@ -507,6 +556,7 @@ CapitalAHat:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH CIRCUMFLEX
   wl-unicode: "\xC2"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+
 CapitalARing:
   esc-alias: Ao
   has-unicode-inverse: true
@@ -515,6 +565,7 @@ CapitalARing:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH RING ABOVE
   wl-unicode: "\xC5"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH RING ABOVE
+
 CapitalATilde:
   esc-alias: A~
   has-unicode-inverse: true
@@ -523,6 +574,7 @@ CapitalATilde:
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH TILDE
   wl-unicode: "\xC3"
   wl-unicode-name: LATIN CAPITAL LETTER A WITH TILDE
+
 CapitalAlpha:
   esc-alias: A
   has-unicode-inverse: true
@@ -531,6 +583,7 @@ CapitalAlpha:
   unicode-equivalent-name: GREEK CAPITAL LETTER ALPHA
   wl-unicode: "\u0391"
   wl-unicode-name: GREEK CAPITAL LETTER ALPHA
+
 CapitalBeta:
   esc-alias: B
   has-unicode-inverse: true
@@ -539,6 +592,7 @@ CapitalBeta:
   unicode-equivalent-name: GREEK CAPITAL LETTER BETA
   wl-unicode: "\u0392"
   wl-unicode-name: GREEK CAPITAL LETTER BETA
+
 CapitalCAcute:
   amslatex: "\\'{C}"
   esc-alias: C'
@@ -548,6 +602,7 @@ CapitalCAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER C WITH ACUTE
   wl-unicode: "\u0106"
   wl-unicode-name: LATIN CAPITAL LETTER C WITH ACUTE
+
 CapitalCCedilla:
   esc-alias: C
   has-unicode-inverse: false
@@ -556,6 +611,7 @@ CapitalCCedilla:
   unicode-equivalent-name: LATIN CAPITAL LETTER C WITH CEDILLA
   wl-unicode: "\xC7"
   wl-unicode-name: LATIN CAPITAL LETTER C WITH CEDILLA
+
 CapitalCHacek:
   amslatex: "\\v{C}"
   esc-alias: Cv
@@ -565,6 +621,7 @@ CapitalCHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER C WITH CARON
   wl-unicode: "\u010C"
   wl-unicode-name: LATIN CAPITAL LETTER C WITH CARON
+
 CapitalChi:
   esc-alias: Ch
   has-unicode-inverse: false
@@ -573,6 +630,7 @@ CapitalChi:
   unicode-equivalent-name: GREEK CAPITAL LETTER CHI
   wl-unicode: "\u03A7"
   wl-unicode-name: GREEK CAPITAL LETTER CHI
+
 CapitalDHacek:
   amslatex: "\\v{D}"
   esc-alias: Dv
@@ -582,6 +640,7 @@ CapitalDHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER D WITH CARON
   wl-unicode: "\u010E"
   wl-unicode-name: LATIN CAPITAL LETTER D WITH CARON
+
 CapitalDelta:
   amslatex: "\\Delta"
   esc-alias: D
@@ -591,6 +650,7 @@ CapitalDelta:
   unicode-equivalent-name: GREEK CAPITAL LETTER DELTA
   wl-unicode: "\u0394"
   wl-unicode-name: GREEK CAPITAL LETTER DELTA
+
 CapitalDifferentialD:
   amslatex: "\\CapitalDifferentialD"
   esc-alias: DD
@@ -599,6 +659,7 @@ CapitalDifferentialD:
   unicode-equivalent: "\u2145"
   unicode-equivalent-name: DOUBLE-STRUCK ITALIC CAPITAL D
   wl-unicode: "\uF74B"
+
 CapitalDigamma:
   esc-alias: Di
   has-unicode-inverse: false
@@ -607,6 +668,7 @@ CapitalDigamma:
   unicode-equivalent-name: GREEK LETTER DIGAMMA
   wl-unicode: "\u03DC"
   wl-unicode-name: GREEK LETTER DIGAMMA
+
 CapitalEAcute:
   amslatex: "\\'{E}"
   esc-alias: E'
@@ -616,6 +678,7 @@ CapitalEAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH ACUTE
   wl-unicode: "\xC9"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH ACUTE
+
 CapitalEBar:
   amslatex: "\\={E}"
   esc-alias: E-
@@ -625,6 +688,7 @@ CapitalEBar:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH MACRON
   wl-unicode: "\u0112"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH MACRON
+
 CapitalECup:
   amslatex: "\\u{E}"
   esc-alias: Eu
@@ -634,6 +698,7 @@ CapitalECup:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH BREVE
   wl-unicode: "\u0114"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH BREVE
+
 CapitalEDoubleDot:
   esc-alias: E"
   has-unicode-inverse: false
@@ -642,6 +707,7 @@ CapitalEDoubleDot:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH DIAERESIS
   wl-unicode: "\xCB"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH DIAERESIS
+
 CapitalEGrave:
   amslatex: "\\`{E}"
   esc-alias: E`
@@ -651,6 +717,7 @@ CapitalEGrave:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH GRAVE
   wl-unicode: "\xC8"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH GRAVE
+
 CapitalEHacek:
   amslatex: "\\v{E}"
   esc-alias: Ev
@@ -660,6 +727,7 @@ CapitalEHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH CARON
   wl-unicode: "\u011A"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH CARON
+
 CapitalEHat:
   esc-alias: E^
   has-unicode-inverse: false
@@ -668,6 +736,7 @@ CapitalEHat:
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH CIRCUMFLEX
   wl-unicode: "\xCA"
   wl-unicode-name: LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+
 CapitalEpsilon:
   esc-alias: E
   has-unicode-inverse: false
@@ -676,6 +745,7 @@ CapitalEpsilon:
   unicode-equivalent-name: GREEK CAPITAL LETTER EPSILON
   wl-unicode: "\u0395"
   wl-unicode-name: GREEK CAPITAL LETTER EPSILON
+
 CapitalEta:
   esc-alias: Et
   has-unicode-inverse: false
@@ -684,6 +754,7 @@ CapitalEta:
   unicode-equivalent-name: GREEK CAPITAL LETTER ETA
   wl-unicode: "\u0397"
   wl-unicode-name: GREEK CAPITAL LETTER ETA
+
 CapitalEth:
   esc-alias: D-
   has-unicode-inverse: false
@@ -692,6 +763,7 @@ CapitalEth:
   unicode-equivalent-name: LATIN CAPITAL LETTER ETH
   wl-unicode: "\xD0"
   wl-unicode-name: LATIN CAPITAL LETTER ETH
+
 CapitalGamma:
   amslatex: "\\Gamma"
   esc-alias: G
@@ -701,6 +773,7 @@ CapitalGamma:
   unicode-equivalent-name: GREEK CAPITAL LETTER GAMMA
   wl-unicode: "\u0393"
   wl-unicode-name: GREEK CAPITAL LETTER GAMMA
+
 CapitalIAcute:
   amslatex: "\\'{I}"
   esc-alias: I'
@@ -710,6 +783,7 @@ CapitalIAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER I WITH ACUTE
   wl-unicode: "\xCD"
   wl-unicode-name: LATIN CAPITAL LETTER I WITH ACUTE
+
 CapitalICup:
   amslatex: "\\u{I}"
   esc-alias: Iu
@@ -719,6 +793,7 @@ CapitalICup:
   unicode-equivalent-name: LATIN CAPITAL LETTER I WITH BREVE
   wl-unicode: "\u012C"
   wl-unicode-name: LATIN CAPITAL LETTER I WITH BREVE
+
 CapitalIDoubleDot:
   esc-alias: I"
   has-unicode-inverse: false
@@ -727,6 +802,7 @@ CapitalIDoubleDot:
   unicode-equivalent-name: LATIN CAPITAL LETTER I WITH DIAERESIS
   wl-unicode: "\xCF"
   wl-unicode-name: LATIN CAPITAL LETTER I WITH DIAERESIS
+
 CapitalIGrave:
   amslatex: "\\`{I}"
   esc-alias: I`
@@ -736,6 +812,7 @@ CapitalIGrave:
   unicode-equivalent-name: LATIN CAPITAL LETTER I WITH GRAVE
   wl-unicode: "\xCC"
   wl-unicode-name: LATIN CAPITAL LETTER I WITH GRAVE
+
 CapitalIHat:
   esc-alias: I^
   has-unicode-inverse: false
@@ -744,6 +821,7 @@ CapitalIHat:
   unicode-equivalent-name: LATIN CAPITAL LETTER I WITH CIRCUMFLEX
   wl-unicode: "\xCE"
   wl-unicode-name: LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+
 CapitalIota:
   esc-alias: I
   has-unicode-inverse: false
@@ -752,6 +830,7 @@ CapitalIota:
   unicode-equivalent-name: GREEK CAPITAL LETTER IOTA
   wl-unicode: "\u0399"
   wl-unicode-name: GREEK CAPITAL LETTER IOTA
+
 CapitalKappa:
   esc-alias: K
   has-unicode-inverse: false
@@ -760,6 +839,7 @@ CapitalKappa:
   unicode-equivalent-name: GREEK CAPITAL LETTER KAPPA
   wl-unicode: "\u039A"
   wl-unicode-name: GREEK CAPITAL LETTER KAPPA
+
 CapitalKoppa:
   esc-alias: Ko
   has-unicode-inverse: false
@@ -768,6 +848,7 @@ CapitalKoppa:
   unicode-equivalent-name: GREEK LETTER KOPPA
   wl-unicode: "\u03DE"
   wl-unicode-name: GREEK LETTER KOPPA
+
 CapitalLSlash:
   amslatex: "\\L{}"
   esc-alias: L/
@@ -777,6 +858,7 @@ CapitalLSlash:
   unicode-equivalent-name: LATIN CAPITAL LETTER L WITH STROKE
   wl-unicode: "\u0141"
   wl-unicode-name: LATIN CAPITAL LETTER L WITH STROKE
+
 CapitalLambda:
   amslatex: "\\Lambda"
   esc-alias: L
@@ -786,6 +868,7 @@ CapitalLambda:
   unicode-equivalent-name: GREEK CAPITAL LETTER LAMDA
   wl-unicode: "\u039B"
   wl-unicode-name: GREEK CAPITAL LETTER LAMDA
+
 CapitalMu:
   esc-alias: M
   has-unicode-inverse: false
@@ -794,6 +877,7 @@ CapitalMu:
   unicode-equivalent-name: GREEK CAPITAL LETTER MU
   wl-unicode: "\u039C"
   wl-unicode-name: GREEK CAPITAL LETTER MU
+
 CapitalNHacek:
   amslatex: "\\v{N}"
   esc-alias: Nv
@@ -803,6 +887,7 @@ CapitalNHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER N WITH CARON
   wl-unicode: "\u0147"
   wl-unicode-name: LATIN CAPITAL LETTER N WITH CARON
+
 CapitalNTilde:
   esc-alias: N~
   has-unicode-inverse: false
@@ -811,6 +896,7 @@ CapitalNTilde:
   unicode-equivalent-name: LATIN CAPITAL LETTER N WITH TILDE
   wl-unicode: "\xD1"
   wl-unicode-name: LATIN CAPITAL LETTER N WITH TILDE
+
 CapitalNu:
   esc-alias: N
   has-unicode-inverse: false
@@ -819,6 +905,7 @@ CapitalNu:
   unicode-equivalent-name: GREEK CAPITAL LETTER NU
   wl-unicode: "\u039D"
   wl-unicode-name: GREEK CAPITAL LETTER NU
+
 CapitalOAcute:
   amslatex: "\\'{O}"
   esc-alias: O'
@@ -828,6 +915,7 @@ CapitalOAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH ACUTE
   wl-unicode: "\xD3"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH ACUTE
+
 CapitalODoubleAcute:
   esc-alias: O''
   has-unicode-inverse: false
@@ -836,6 +924,7 @@ CapitalODoubleAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
   wl-unicode: "\u0150"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
+
 CapitalODoubleDot:
   esc-alias: O"
   has-unicode-inverse: false
@@ -844,6 +933,7 @@ CapitalODoubleDot:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH DIAERESIS
   wl-unicode: "\xD6"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH DIAERESIS
+
 CapitalOE:
   esc-alias: OE
   has-unicode-inverse: false
@@ -852,6 +942,7 @@ CapitalOE:
   unicode-equivalent-name: LATIN CAPITAL LIGATURE OE
   wl-unicode: "\u0152"
   wl-unicode-name: LATIN CAPITAL LIGATURE OE
+
 CapitalOGrave:
   amslatex: "\\`{O}"
   esc-alias: O`
@@ -861,6 +952,7 @@ CapitalOGrave:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH GRAVE
   wl-unicode: "\xD2"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH GRAVE
+
 CapitalOHat:
   amslatex: "\\^{O}"
   esc-alias: O^
@@ -870,6 +962,7 @@ CapitalOHat:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH CIRCUMFLEX
   wl-unicode: "\xD4"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+
 CapitalOSlash:
   amslatex: "\\O{}"
   esc-alias: O/
@@ -879,6 +972,7 @@ CapitalOSlash:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH STROKE
   wl-unicode: "\xD8"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH STROKE
+
 CapitalOTilde:
   esc-alias: O~
   has-unicode-inverse: false
@@ -887,6 +981,7 @@ CapitalOTilde:
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH TILDE
   wl-unicode: "\xD5"
   wl-unicode-name: LATIN CAPITAL LETTER O WITH TILDE
+
 CapitalOmega:
   amslatex: "\\Omega"
   esc-alias: O
@@ -896,6 +991,7 @@ CapitalOmega:
   unicode-equivalent-name: GREEK CAPITAL LETTER OMEGA
   wl-unicode: "\u03A9"
   wl-unicode-name: GREEK CAPITAL LETTER OMEGA
+
 CapitalOmicron:
   esc-alias: Om
   has-unicode-inverse: false
@@ -904,6 +1000,7 @@ CapitalOmicron:
   unicode-equivalent-name: GREEK CAPITAL LETTER OMICRON
   wl-unicode: "\u039F"
   wl-unicode-name: GREEK CAPITAL LETTER OMICRON
+
 CapitalPhi:
   amslatex: "\\Phi"
   esc-alias: Ph
@@ -913,6 +1010,7 @@ CapitalPhi:
   unicode-equivalent-name: GREEK CAPITAL LETTER PHI
   wl-unicode: "\u03A6"
   wl-unicode-name: GREEK CAPITAL LETTER PHI
+
 CapitalPi:
   amslatex: "\\Pi"
   esc-alias: P
@@ -922,6 +1020,7 @@ CapitalPi:
   unicode-equivalent-name: GREEK CAPITAL LETTER PI
   wl-unicode: "\u03A0"
   wl-unicode-name: GREEK CAPITAL LETTER PI
+
 CapitalPsi:
   amslatex: "\\Psi"
   esc-alias: Ps
@@ -931,6 +1030,7 @@ CapitalPsi:
   unicode-equivalent-name: GREEK CAPITAL LETTER PSI
   wl-unicode: "\u03A8"
   wl-unicode-name: GREEK CAPITAL LETTER PSI
+
 CapitalRHacek:
   amslatex: "\\v{R}"
   esc-alias: Rv
@@ -940,6 +1040,7 @@ CapitalRHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER R WITH CARON
   wl-unicode: "\u0158"
   wl-unicode-name: LATIN CAPITAL LETTER R WITH CARON
+
 CapitalRho:
   esc-alias: R
   has-unicode-inverse: false
@@ -948,6 +1049,7 @@ CapitalRho:
   unicode-equivalent-name: GREEK CAPITAL LETTER RHO
   wl-unicode: "\u03A1"
   wl-unicode-name: GREEK CAPITAL LETTER RHO
+
 CapitalSHacek:
   amslatex: "\\v{S}"
   esc-alias: Sv
@@ -957,6 +1059,7 @@ CapitalSHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER S WITH CARON
   wl-unicode: "\u0160"
   wl-unicode-name: LATIN CAPITAL LETTER S WITH CARON
+
 CapitalSampi:
   esc-alias: Sa
   has-unicode-inverse: false
@@ -965,6 +1068,7 @@ CapitalSampi:
   unicode-equivalent-name: GREEK LETTER SAMPI
   wl-unicode: "\u03E0"
   wl-unicode-name: GREEK LETTER SAMPI
+
 CapitalSigma:
   amslatex: "\\Sigma"
   esc-alias: S
@@ -974,6 +1078,7 @@ CapitalSigma:
   unicode-equivalent-name: GREEK CAPITAL LETTER SIGMA
   wl-unicode: "\u03A3"
   wl-unicode-name: GREEK CAPITAL LETTER SIGMA
+
 CapitalStigma:
   esc-alias: Sti
   has-unicode-inverse: false
@@ -982,6 +1087,7 @@ CapitalStigma:
   unicode-equivalent-name: GREEK LETTER STIGMA
   wl-unicode: "\u03DA"
   wl-unicode-name: GREEK LETTER STIGMA
+
 CapitalTHacek:
   amslatex: "\\v{T}"
   esc-alias: Tv
@@ -991,6 +1097,7 @@ CapitalTHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER T WITH CARON
   wl-unicode: "\u0164"
   wl-unicode-name: LATIN CAPITAL LETTER T WITH CARON
+
 CapitalTau:
   esc-alias: T
   has-unicode-inverse: false
@@ -999,6 +1106,7 @@ CapitalTau:
   unicode-equivalent-name: GREEK CAPITAL LETTER TAU
   wl-unicode: "\u03A4"
   wl-unicode-name: GREEK CAPITAL LETTER TAU
+
 CapitalTheta:
   amslatex: "\\Theta"
   esc-alias: Th
@@ -1008,6 +1116,7 @@ CapitalTheta:
   unicode-equivalent-name: GREEK CAPITAL LETTER THETA
   wl-unicode: "\u0398"
   wl-unicode-name: GREEK CAPITAL LETTER THETA
+
 CapitalThorn:
   esc-alias: Thn
   has-unicode-inverse: false
@@ -1016,6 +1125,7 @@ CapitalThorn:
   unicode-equivalent-name: LATIN CAPITAL LETTER THORN
   wl-unicode: "\xDE"
   wl-unicode-name: LATIN CAPITAL LETTER THORN
+
 CapitalUAcute:
   amslatex: "\\'{U}"
   esc-alias: U'
@@ -1025,6 +1135,7 @@ CapitalUAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH ACUTE
   wl-unicode: "\xDA"
   wl-unicode-name: LATIN CAPITAL LETTER U WITH ACUTE
+
 CapitalUDoubleAcute:
   esc-alias: U''
   has-unicode-inverse: false
@@ -1033,6 +1144,7 @@ CapitalUDoubleAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
   wl-unicode: "\u0170"
   wl-unicode-name: LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
+
 CapitalUDoubleDot:
   esc-alias: U"
   has-unicode-inverse: false
@@ -1041,6 +1153,7 @@ CapitalUDoubleDot:
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH DIAERESIS
   wl-unicode: "\xDC"
   wl-unicode-name: LATIN CAPITAL LETTER U WITH DIAERESIS
+
 CapitalUGrave:
   amslatex: "\\`{U}"
   esc-alias: U`
@@ -1050,6 +1163,7 @@ CapitalUGrave:
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH GRAVE
   wl-unicode: "\xD9"
   wl-unicode-name: LATIN CAPITAL LETTER U WITH GRAVE
+
 CapitalUHat:
   esc-alias: U^
   has-unicode-inverse: false
@@ -1058,6 +1172,7 @@ CapitalUHat:
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH CIRCUMFLEX
   wl-unicode: "\xDB"
   wl-unicode-name: LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+
 CapitalURing:
   esc-alias: Uo
   has-unicode-inverse: false
@@ -1066,6 +1181,7 @@ CapitalURing:
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH RING ABOVE
   wl-unicode: "\u016E"
   wl-unicode-name: LATIN CAPITAL LETTER U WITH RING ABOVE
+
 CapitalUpsilon:
   amslatex: "\\Upsilon"
   esc-alias: U
@@ -1075,6 +1191,7 @@ CapitalUpsilon:
   unicode-equivalent-name: GREEK CAPITAL LETTER UPSILON
   wl-unicode: "\u03A5"
   wl-unicode-name: GREEK CAPITAL LETTER UPSILON
+
 CapitalXi:
   amslatex: "\\Xi"
   esc-alias: X
@@ -1084,6 +1201,7 @@ CapitalXi:
   unicode-equivalent-name: GREEK CAPITAL LETTER XI
   wl-unicode: "\u039E"
   wl-unicode-name: GREEK CAPITAL LETTER XI
+
 CapitalYAcute:
   amslatex: "\\'{Y}"
   esc-alias: Y'
@@ -1093,6 +1211,7 @@ CapitalYAcute:
   unicode-equivalent-name: LATIN CAPITAL LETTER Y WITH ACUTE
   wl-unicode: "\xDD"
   wl-unicode-name: LATIN CAPITAL LETTER Y WITH ACUTE
+
 CapitalZHacek:
   amslatex: "\\v{Z}"
   esc-alias: Zv
@@ -1102,6 +1221,7 @@ CapitalZHacek:
   unicode-equivalent-name: LATIN CAPITAL LETTER Z WITH CARON
   wl-unicode: "\u017D"
   wl-unicode-name: LATIN CAPITAL LETTER Z WITH CARON
+
 CapitalZeta:
   esc-alias: Z
   has-unicode-inverse: false
@@ -1110,6 +1230,7 @@ CapitalZeta:
   unicode-equivalent-name: GREEK CAPITAL LETTER ZETA
   wl-unicode: "\u0396"
   wl-unicode-name: GREEK CAPITAL LETTER ZETA
+
 CapricornSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1117,6 +1238,7 @@ CapricornSign:
   unicode-equivalent-name: CAPRICORN
   wl-unicode: "\u2651"
   wl-unicode-name: CAPRICORN
+
 Cedilla:
   esc-alias: cd
   has-unicode-inverse: false
@@ -1125,6 +1247,7 @@ Cedilla:
   unicode-equivalent-name: CEDILLA
   wl-unicode: "\xB8"
   wl-unicode-name: CEDILLA
+
 Cent:
   esc-alias: cent
   has-unicode-inverse: false
@@ -1133,6 +1256,7 @@ Cent:
   unicode-equivalent-name: CENT SIGN
   wl-unicode: "\xA2"
   wl-unicode-name: CENT SIGN
+
 CenterDot:
   esc-alias: .
   has-unicode-inverse: false
@@ -1142,6 +1266,7 @@ CenterDot:
   unicode-equivalent-name: MIDDLE DOT
   wl-unicode: "\xB7"
   wl-unicode-name: MIDDLE DOT
+
 CenterEllipsis:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1149,6 +1274,7 @@ CenterEllipsis:
   unicode-equivalent-name: MIDLINE HORIZONTAL ELLIPSIS
   wl-unicode: "\u22EF"
   wl-unicode-name: MIDLINE HORIZONTAL ELLIPSIS
+
 CheckedBox:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1156,6 +1282,7 @@ CheckedBox:
   unicode-equivalent-name: BALLOT BOX WITH X
   wl-unicode: "\u2612"
   wl-unicode-name: BALLOT BOX WITH X
+
 Checkmark:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1163,6 +1290,7 @@ Checkmark:
   unicode-equivalent-name: CHECK MARK
   wl-unicode: "\u2713"
   wl-unicode-name: CHECK MARK
+
 Chi:
   amslatex: "\\chi"
   esc-alias: ch
@@ -1172,6 +1300,7 @@ Chi:
   unicode-equivalent-name: GREEK SMALL LETTER CHI
   wl-unicode: "\u03C7"
   wl-unicode-name: GREEK SMALL LETTER CHI
+
 CircleDot:
   amslatex: "\\odot"
   esc-alias: c.
@@ -1182,6 +1311,7 @@ CircleDot:
   unicode-equivalent-name: CIRCLED DOT OPERATOR
   wl-unicode: "\u2299"
   wl-unicode-name: CIRCLED DOT OPERATOR
+
 CircleMinus:
   amslatex: "\\ominus"
   esc-alias: c-
@@ -1192,6 +1322,7 @@ CircleMinus:
   unicode-equivalent-name: CIRCLED MINUS
   wl-unicode: "\u2296"
   wl-unicode-name: CIRCLED MINUS
+
 CirclePlus:
   amslatex: "\\oplus"
   esc-alias: c+
@@ -1202,6 +1333,7 @@ CirclePlus:
   unicode-equivalent-name: CIRCLED PLUS
   wl-unicode: "\u2295"
   wl-unicode-name: CIRCLED PLUS
+
 CircleTimes:
   amslatex: "\\otimes"
   esc-alias: c*
@@ -1212,6 +1344,7 @@ CircleTimes:
   unicode-equivalent-name: CIRCLED TIMES
   wl-unicode: "\u2297"
   wl-unicode-name: CIRCLED TIMES
+
 ClockwiseContourIntegral:
   esc-alias: ccint
   has-unicode-inverse: false
@@ -1221,6 +1354,7 @@ ClockwiseContourIntegral:
   unicode-equivalent-name: CLOCKWISE CONTOUR INTEGRAL
   wl-unicode: "\u2232"
   wl-unicode-name: CLOCKWISE CONTOUR INTEGRAL
+
 CloseCurlyDoubleQuote:
   esc-alias: ']"'
   has-unicode-inverse: false
@@ -1229,6 +1363,7 @@ CloseCurlyDoubleQuote:
   unicode-equivalent-name: RIGHT DOUBLE QUOTATION MARK
   wl-unicode: "\u201D"
   wl-unicode-name: RIGHT DOUBLE QUOTATION MARK
+
 CloseCurlyQuote:
   esc-alias: ']'''
   has-unicode-inverse: false
@@ -1237,6 +1372,7 @@ CloseCurlyQuote:
   unicode-equivalent-name: RIGHT SINGLE QUOTATION MARK
   wl-unicode: "\u2019"
   wl-unicode-name: RIGHT SINGLE QUOTATION MARK
+
 CloverLeaf:
   esc-alias: cl
   has-unicode-inverse: false
@@ -1245,6 +1381,7 @@ CloverLeaf:
   unicode-equivalent-name: PLACE OF INTEREST SIGN
   wl-unicode: "\u2318"
   wl-unicode-name: PLACE OF INTEREST SIGN
+
 ClubSuit:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1252,6 +1389,7 @@ ClubSuit:
   unicode-equivalent-name: BLACK CLUB SUIT
   wl-unicode: "\u2663"
   wl-unicode-name: BLACK CLUB SUIT
+
 Colon:
   esc-alias: ':'
   has-unicode-inverse: false
@@ -1262,6 +1400,7 @@ Colon:
   unicode-equivalent-name: RATIO
   wl-unicode: "\u2236"
   wl-unicode-name: RATIO
+
 CommandKey:
   esc-alias: cmd
   has-unicode-inverse: true
@@ -1269,17 +1408,20 @@ CommandKey:
   unicode-equivalent: "\u2318"
   unicode-equivalent-name: PLACE OF INTEREST SIGN
   wl-unicode: "\uF76A"
+
 Composition:
   ascii: "@*"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Composition
+
 CompoundExpression:
   ascii: ";"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: CompoundExpression
   precedence: 10
+
 Condition:
   ascii: "/;"
   has-unicode-inverse: false
@@ -1291,6 +1433,7 @@ Conditioned:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3D3"
+
 Congruent:
   amslatex: "===" # FIXME: can we do better here?
   esc-alias: ===
@@ -1301,18 +1444,21 @@ Congruent:
   unicode-equivalent-name: IDENTICAL TO
   wl-unicode: "\u2261"
   wl-unicode-name: IDENTICAL TO
+
 Conjugate:
   esc-alias: co
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Conjugate
   wl-unicode: "\uF3C8"
+
 ConjugateTranspose:
   esc-alias: ct
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: ConjugateTranspose
   wl-unicode: "\uF3C9"
+
 ConstantC:
   esc-alias: cc
   has-unicode-inverse: false
@@ -1320,6 +1466,7 @@ ConstantC:
   unicode-equivalent: "\U0001D554"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL C
   wl-unicode: "\uF7DA"
+
 Continuation:
   esc-alias: cont
   has-unicode-inverse: false
@@ -1327,6 +1474,7 @@ Continuation:
   unicode-equivalent: "\u22F1"
   unicode-equivalent-name: DOWN RIGHT DIAGONAL ELLIPSIS
   wl-unicode: "\uF3B1"
+
 ContourIntegral:
   amslatex: "\\oint"
   esc-alias: cint
@@ -1337,11 +1485,13 @@ ContourIntegral:
   unicode-equivalent-name: CONTOUR INTEGRAL
   wl-unicode: "\u222E"
   wl-unicode-name: CONTOUR INTEGRAL
+
 ControlKey:
   esc-alias: ctrl
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF763"
+
 Coproduct:
   amslatex: "\\coprod"
   esc-alias: coprod
@@ -1352,6 +1502,7 @@ Coproduct:
   unicode-equivalent-name: N-ARY COPRODUCT
   wl-unicode: "\u2210"
   wl-unicode-name: N-ARY COPRODUCT
+
 Copyright:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1359,6 +1510,7 @@ Copyright:
   unicode-equivalent-name: COPYRIGHT SIGN
   wl-unicode: "\xA9"
   wl-unicode-name: COPYRIGHT SIGN
+
 CounterClockwiseContourIntegral:
   esc-alias: cccint
   has-unicode-inverse: false
@@ -1368,6 +1520,7 @@ CounterClockwiseContourIntegral:
   unicode-equivalent-name: ANTICLOCKWISE CONTOUR INTEGRAL
   wl-unicode: "\u2233"
   wl-unicode-name: ANTICLOCKWISE CONTOUR INTEGRAL
+
 Cross:
   esc-alias: cross
   has-unicode-inverse: true
@@ -1375,6 +1528,7 @@ Cross:
   unicode-equivalent: "\u2A2F"
   unicode-equivalent-name: VECTOR OR CROSS PRODUCT
   wl-unicode: "\uF4A0"
+
 Cup:
   amslatex: "\\cup"
   has-unicode-inverse: false
@@ -1384,6 +1538,7 @@ Cup:
   unicode-equivalent-name: SMILE
   wl-unicode: "\u2323"
   wl-unicode-name: SMILE
+
 CupCap:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1392,6 +1547,7 @@ CupCap:
   unicode-equivalent-name: EQUIVALENT TO
   wl-unicode: "\u224D"
   wl-unicode-name: EQUIVALENT TO
+
 CurlyCapitalUpsilon:
   esc-alias: cU
   has-unicode-inverse: false
@@ -1400,6 +1556,7 @@ CurlyCapitalUpsilon:
   unicode-equivalent-name: GREEK UPSILON WITH HOOK SYMBOL
   wl-unicode: "\u03D2"
   wl-unicode-name: GREEK UPSILON WITH HOOK SYMBOL
+
 CurlyEpsilon:
   esc-alias: ce
   has-unicode-inverse: false
@@ -1408,6 +1565,7 @@ CurlyEpsilon:
   unicode-equivalent-name: GREEK SMALL LETTER EPSILON
   wl-unicode: "\u03B5"
   wl-unicode-name: GREEK SMALL LETTER EPSILON
+
 CurlyKappa:
   esc-alias: ck
   has-unicode-inverse: false
@@ -1416,6 +1574,7 @@ CurlyKappa:
   unicode-equivalent-name: GREEK KAPPA SYMBOL
   wl-unicode: "\u03F0"
   wl-unicode-name: GREEK KAPPA SYMBOL
+
 CurlyPhi:
   esc-alias: j
   has-unicode-inverse: false
@@ -1424,6 +1583,7 @@ CurlyPhi:
   unicode-equivalent-name: GREEK SMALL LETTER PHI
   wl-unicode: "\u03C6"
   wl-unicode-name: GREEK SMALL LETTER PHI
+
 CurlyPi:
   esc-alias: cp
   has-unicode-inverse: false
@@ -1432,6 +1592,7 @@ CurlyPi:
   unicode-equivalent-name: GREEK PI SYMBOL
   wl-unicode: "\u03D6"
   wl-unicode-name: GREEK PI SYMBOL
+
 CurlyRho:
   esc-alias: cr
   has-unicode-inverse: false
@@ -1440,6 +1601,7 @@ CurlyRho:
   unicode-equivalent-name: GREEK RHO SYMBOL
   wl-unicode: "\u03F1"
   wl-unicode-name: GREEK RHO SYMBOL
+
 CurlyTheta:
   esc-alias: cq
   has-unicode-inverse: false
@@ -1448,6 +1610,7 @@ CurlyTheta:
   unicode-equivalent-name: GREEK THETA SYMBOL
   wl-unicode: "\u03D1"
   wl-unicode-name: GREEK THETA SYMBOL
+
 Currency:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1455,6 +1618,7 @@ Currency:
   unicode-equivalent-name: CURRENCY SIGN
   wl-unicode: "\xA4"
   wl-unicode-name: CURRENCY SIGN
+
 DHacek:
   amslatex: "\\v{d}"
   esc-alias: dv
@@ -1464,6 +1628,7 @@ DHacek:
   unicode-equivalent-name: LATIN SMALL LETTER D WITH CARON
   wl-unicode: "\u010F"
   wl-unicode-name: LATIN SMALL LETTER D WITH CARON
+
 Dagger:
   amslatex: "\\dagger"
   esc-alias: dg
@@ -1473,6 +1638,7 @@ Dagger:
   unicode-equivalent-name: DAGGER
   wl-unicode: "\u2020"
   wl-unicode-name: DAGGER
+
 Dalet:
   amslatex: "\\daleth"
   esc-alias: da
@@ -1482,6 +1648,7 @@ Dalet:
   unicode-equivalent-name: DALET SYMBOL
   wl-unicode: "\u2138"
   wl-unicode-name: DALET SYMBOL
+
 Dash:
   esc-alias: '-'
   has-unicode-inverse: false
@@ -1490,6 +1657,7 @@ Dash:
   unicode-equivalent-name: EN DASH
   wl-unicode: "\u2013"
   wl-unicode-name: EN DASH
+
 Decrement:
   ascii: "--"
   has-unicode-inverse: false
@@ -1498,6 +1666,7 @@ Decrement:
   precedence: 660
 
 # See also PatternTest and RawQuestion
+
 Definition:
   ascii: "?"
   has-unicode-inverse: false
@@ -1541,11 +1710,13 @@ Del:
   unicode-equivalent-name: NABLA
   wl-unicode: "\u2207"
   wl-unicode-name: NABLA
+
 DeleteKey:
   esc-alias: ' del'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7D0"
+
 Delta:
   amslatex: "\\delta"
   esc-alias: d
@@ -1555,12 +1726,14 @@ Delta:
   unicode-equivalent-name: GREEK SMALL LETTER DELTA
   wl-unicode: "\u03B4"
   wl-unicode-name: GREEK SMALL LETTER DELTA
+
 Derivative:
   ascii: "'"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Derivative
   precedence: 670
+
 DescendingEllipsis:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1568,6 +1741,7 @@ DescendingEllipsis:
   unicode-equivalent-name: DOWN RIGHT DIAGONAL ELLIPSIS
   wl-unicode: "\u22F1"
   wl-unicode-name: DOWN RIGHT DIAGONAL ELLIPSIS
+
 Diameter:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1575,6 +1749,7 @@ Diameter:
   unicode-equivalent-name: DIAMETER SIGN
   wl-unicode: "\u2300"
   wl-unicode-name: DIAMETER SIGN
+
 Diamond:
   amslatex: "\\diamond"
   esc-alias: dia
@@ -1584,6 +1759,7 @@ Diamond:
   unicode-equivalent-name: DIAMOND OPERATOR
   wl-unicode: "\u22C4"
   wl-unicode-name: DIAMOND OPERATOR
+
 DiamondSuit:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1591,6 +1767,7 @@ DiamondSuit:
   unicode-equivalent-name: WHITE DIAMOND SUIT
   wl-unicode: "\u2662"
   wl-unicode-name: WHITE DIAMOND SUIT
+
 DifferenceDelta:
   esc-alias: diffd
   has-unicode-inverse: false
@@ -1613,6 +1790,7 @@ DifferentialD:
   unicode-equivalent: "\U0001D451"
   unicode-equivalent-name: MATHEMATICAL ITALIC SMALL D
   wl-unicode: "\uF74C"
+
 Digamma:
   esc-alias: di
   has-unicode-inverse: false
@@ -1621,6 +1799,7 @@ Digamma:
   unicode-equivalent-name: GREEK SMALL LETTER DIGAMMA
   wl-unicode: "\u03DD"
   wl-unicode-name: GREEK SMALL LETTER DIGAMMA
+
 DirectedEdge:
   amslatex: "\\rightarrow"
   esc-alias: de
@@ -1629,6 +1808,7 @@ DirectedEdge:
   unicode-equivalent: "\u2192"
   unicode-equivalent-name: RIGHTWARDS ARROW
   wl-unicode: "\uF3D5"
+
 DiscreteRatio:
   esc-alias: dratio
   has-unicode-inverse: true
@@ -1636,27 +1816,32 @@ DiscreteRatio:
   unicode-equivalent: "\u03F4"
   unicode-equivalent-name: GREEK CAPITAL THETA SYMBOL
   wl-unicode: "\uF4A4"
+
 DiscreteShift:
   esc-alias: shift
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF4A3"
+
 DiscretionaryHyphen:
   esc-alias: dhy
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\xAD"
   wl-unicode-name: SOFT HYPHEN
+
 DiscretionaryLineSeparator:
   esc-alias: dlsep
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF76E"
+
 DiscretionaryPageBreakAbove:
   esc-alias: dpba
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3BF"
+
 DiscretionaryPageBreakBelow:
   esc-alias: dpbb
   has-unicode-inverse: false
@@ -1802,6 +1987,7 @@ DoubleLeftRightArrow:
   unicode-equivalent-name: LEFT RIGHT DOUBLE ARROW
   wl-unicode: "\u21D4"
   wl-unicode-name: LEFT RIGHT DOUBLE ARROW
+
 DoubleLeftTee:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1810,6 +1996,7 @@ DoubleLeftTee:
   unicode-equivalent-name: VERTICAL BAR DOUBLE LEFT TURNSTILE
   wl-unicode: "\u2AE4"
   wl-unicode-name: VERTICAL BAR DOUBLE LEFT TURNSTILE
+
 DoubleLongLeftArrow:
   esc-alias: <==
   has-unicode-inverse: false
@@ -1819,6 +2006,7 @@ DoubleLongLeftArrow:
   unicode-equivalent-name: LONG LEFTWARDS DOUBLE ARROW
   wl-unicode: "\u27F8"
   wl-unicode-name: LONG LEFTWARDS DOUBLE ARROW
+
 DoubleLongLeftRightArrow:
   esc-alias: <==>
   has-unicode-inverse: false
@@ -1828,6 +2016,7 @@ DoubleLongLeftRightArrow:
   unicode-equivalent-name: LONG LEFT RIGHT DOUBLE ARROW
   wl-unicode: "\u27FA"
   wl-unicode-name: LONG LEFT RIGHT DOUBLE ARROW
+
 DoubleLongRightArrow:
   esc-alias: ==>
   has-unicode-inverse: false
@@ -1837,6 +2026,7 @@ DoubleLongRightArrow:
   unicode-equivalent-name: LONG RIGHTWARDS DOUBLE ARROW
   wl-unicode: "\u27F9"
   wl-unicode-name: LONG RIGHTWARDS DOUBLE ARROW
+
 DoublePrime:
   esc-alias: ''''''
   has-unicode-inverse: false
@@ -1845,6 +2035,7 @@ DoublePrime:
   unicode-equivalent-name: DOUBLE PRIME
   wl-unicode: "\u2033"
   wl-unicode-name: DOUBLE PRIME
+
 DoubleRightArrow:
   amslatex: "\\Rightarrow"
   esc-alias: ' =>'
@@ -1856,6 +2047,7 @@ DoubleRightArrow:
   unicode-equivalent-name: RIGHTWARDS DOUBLE ARROW
   wl-unicode: "\u21D2"
   wl-unicode-name: RIGHTWARDS DOUBLE ARROW
+
 DoubleRightTee:
   has-unicode-inverse: false
   is-letter-like: false
@@ -1864,6 +2056,7 @@ DoubleRightTee:
   operator-name: DoubleRightTee
   wl-unicode: "\u22A8"
   wl-unicode-name: 'TRUE'
+
 DoubleStruckA:
   esc-alias: dsa
   has-unicode-inverse: true
@@ -1871,6 +2064,7 @@ DoubleStruckA:
   unicode-equivalent: "\U0001D552"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL A
   wl-unicode: "\uF6E6"
+
 DoubleStruckB:
   esc-alias: dsb
   has-unicode-inverse: true
@@ -1878,6 +2072,7 @@ DoubleStruckB:
   unicode-equivalent: "\U0001D553"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL B
   wl-unicode: "\uF6E7"
+
 DoubleStruckC:
   esc-alias: dsc
   has-unicode-inverse: true
@@ -1885,6 +2080,7 @@ DoubleStruckC:
   unicode-equivalent: "\U0001D554"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL C
   wl-unicode: "\uF6E8"
+
 DoubleStruckCapitalA:
   esc-alias: dsA
   has-unicode-inverse: true
@@ -1892,6 +2088,7 @@ DoubleStruckCapitalA:
   unicode-equivalent: "\U0001D538"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL A
   wl-unicode: "\uF7A4"
+
 DoubleStruckCapitalB:
   esc-alias: dsB
   has-unicode-inverse: true
@@ -1899,6 +2096,7 @@ DoubleStruckCapitalB:
   unicode-equivalent: "\U0001D539"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL B
   wl-unicode: "\uF7A5"
+
 DoubleStruckCapitalC:
   esc-alias: dsC
   has-unicode-inverse: true
@@ -1906,6 +2104,7 @@ DoubleStruckCapitalC:
   unicode-equivalent: "\u2102"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL C
   wl-unicode: "\uF7A6"
+
 DoubleStruckCapitalD:
   esc-alias: dsD
   has-unicode-inverse: true
@@ -1913,6 +2112,7 @@ DoubleStruckCapitalD:
   unicode-equivalent: "\U0001D53B"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL D
   wl-unicode: "\uF7A7"
+
 DoubleStruckCapitalE:
   esc-alias: dsE
   has-unicode-inverse: true
@@ -1920,6 +2120,7 @@ DoubleStruckCapitalE:
   unicode-equivalent: "\U0001D53C"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL E
   wl-unicode: "\uF7A8"
+
 DoubleStruckCapitalF:
   esc-alias: dsF
   has-unicode-inverse: true
@@ -1927,6 +2128,7 @@ DoubleStruckCapitalF:
   unicode-equivalent: "\U0001D53D"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL F
   wl-unicode: "\uF7A9"
+
 DoubleStruckCapitalG:
   esc-alias: dsG
   has-unicode-inverse: true
@@ -1934,6 +2136,7 @@ DoubleStruckCapitalG:
   unicode-equivalent: "\U0001D53E"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL G
   wl-unicode: "\uF7AA"
+
 DoubleStruckCapitalH:
   esc-alias: dsH
   has-unicode-inverse: true
@@ -1941,6 +2144,7 @@ DoubleStruckCapitalH:
   unicode-equivalent: "\u210D"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL H
   wl-unicode: "\uF7AB"
+
 DoubleStruckCapitalI:
   esc-alias: dsI
   has-unicode-inverse: true
@@ -1948,6 +2152,7 @@ DoubleStruckCapitalI:
   unicode-equivalent: "\U0001D540"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL I
   wl-unicode: "\uF7AC"
+
 DoubleStruckCapitalJ:
   esc-alias: dsJ
   has-unicode-inverse: true
@@ -1955,6 +2160,7 @@ DoubleStruckCapitalJ:
   unicode-equivalent: "\U0001D541"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL J
   wl-unicode: "\uF7AD"
+
 DoubleStruckCapitalK:
   esc-alias: dsK
   has-unicode-inverse: true
@@ -1962,6 +2168,7 @@ DoubleStruckCapitalK:
   unicode-equivalent: "\U0001D542"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL K
   wl-unicode: "\uF7AE"
+
 DoubleStruckCapitalL:
   esc-alias: dsL
   has-unicode-inverse: true
@@ -1969,6 +2176,7 @@ DoubleStruckCapitalL:
   unicode-equivalent: "\U0001D543"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL L
   wl-unicode: "\uF7AF"
+
 DoubleStruckCapitalM:
   esc-alias: dsM
   has-unicode-inverse: true
@@ -1976,6 +2184,7 @@ DoubleStruckCapitalM:
   unicode-equivalent: "\U0001D544"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL M
   wl-unicode: "\uF7B0"
+
 DoubleStruckCapitalN:
   esc-alias: dsN
   has-unicode-inverse: true
@@ -1983,6 +2192,7 @@ DoubleStruckCapitalN:
   unicode-equivalent: "\u2115"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL N
   wl-unicode: "\uF7B1"
+
 DoubleStruckCapitalO:
   esc-alias: dsO
   has-unicode-inverse: true
@@ -1990,6 +2200,7 @@ DoubleStruckCapitalO:
   unicode-equivalent: "\U0001D546"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL O
   wl-unicode: "\uF7B2"
+
 DoubleStruckCapitalP:
   esc-alias: dsP
   has-unicode-inverse: true
@@ -1997,6 +2208,7 @@ DoubleStruckCapitalP:
   unicode-equivalent: "\u2119"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL P
   wl-unicode: "\uF7B3"
+
 DoubleStruckCapitalQ:
   esc-alias: dsQ
   has-unicode-inverse: true
@@ -2004,6 +2216,7 @@ DoubleStruckCapitalQ:
   unicode-equivalent: "\u211A"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL Q
   wl-unicode: "\uF7B4"
+
 DoubleStruckCapitalR:
   esc-alias: dsR
   has-unicode-inverse: true
@@ -2011,6 +2224,7 @@ DoubleStruckCapitalR:
   unicode-equivalent: "\u211D"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL R
   wl-unicode: "\uF7B5"
+
 DoubleStruckCapitalS:
   esc-alias: dsS
   has-unicode-inverse: true
@@ -2018,6 +2232,7 @@ DoubleStruckCapitalS:
   unicode-equivalent: "\U0001D54A"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL S
   wl-unicode: "\uF7B6"
+
 DoubleStruckCapitalT:
   esc-alias: dsT
   has-unicode-inverse: true
@@ -2025,6 +2240,7 @@ DoubleStruckCapitalT:
   unicode-equivalent: "\U0001D54B"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL T
   wl-unicode: "\uF7B7"
+
 DoubleStruckCapitalU:
   esc-alias: dsU
   has-unicode-inverse: true
@@ -2032,6 +2248,7 @@ DoubleStruckCapitalU:
   unicode-equivalent: "\U0001D54C"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL U
   wl-unicode: "\uF7B8"
+
 DoubleStruckCapitalV:
   esc-alias: dsV
   has-unicode-inverse: true
@@ -2039,6 +2256,7 @@ DoubleStruckCapitalV:
   unicode-equivalent: "\U0001D54D"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL V
   wl-unicode: "\uF7B9"
+
 DoubleStruckCapitalW:
   esc-alias: dsW
   has-unicode-inverse: true
@@ -2046,6 +2264,7 @@ DoubleStruckCapitalW:
   unicode-equivalent: "\U0001D54E"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL W
   wl-unicode: "\uF7BA"
+
 DoubleStruckCapitalX:
   esc-alias: dsX
   has-unicode-inverse: true
@@ -2053,6 +2272,7 @@ DoubleStruckCapitalX:
   unicode-equivalent: "\U0001D54F"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL X
   wl-unicode: "\uF7BB"
+
 DoubleStruckCapitalY:
   esc-alias: dsY
   has-unicode-inverse: true
@@ -2060,6 +2280,7 @@ DoubleStruckCapitalY:
   unicode-equivalent: "\U0001D550"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
   wl-unicode: "\uF7BC"
+
 DoubleStruckCapitalZ:
   esc-alias: dsZ
   has-unicode-inverse: true
@@ -2067,6 +2288,7 @@ DoubleStruckCapitalZ:
   unicode-equivalent: "\u2124"
   unicode-equivalent-name: DOUBLE-STRUCK CAPITAL Z
   wl-unicode: "\uF7BD"
+
 DoubleStruckD:
   esc-alias: dsd
   has-unicode-inverse: true
@@ -2074,6 +2296,7 @@ DoubleStruckD:
   unicode-equivalent: "\U0001D555"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL D
   wl-unicode: "\uF6E9"
+
 DoubleStruckE:
   esc-alias: dse
   has-unicode-inverse: true
@@ -2081,6 +2304,7 @@ DoubleStruckE:
   unicode-equivalent: "\U0001D556"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL E
   wl-unicode: "\uF6EA"
+
 DoubleStruckEight:
   esc-alias: ds8
   has-unicode-inverse: true
@@ -2088,6 +2312,7 @@ DoubleStruckEight:
   unicode-equivalent: "\U0001D7E0"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT EIGHT
   wl-unicode: "\uF7E3"
+
 DoubleStruckF:
   esc-alias: dsf
   has-unicode-inverse: true
@@ -2095,6 +2320,7 @@ DoubleStruckF:
   unicode-equivalent: "\U0001D557"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL F
   wl-unicode: "\uF6EB"
+
 DoubleStruckFive:
   esc-alias: ds5
   has-unicode-inverse: true
@@ -2102,6 +2328,7 @@ DoubleStruckFive:
   unicode-equivalent: "\U0001D7DD"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT FIVE
   wl-unicode: "\uF7E0"
+
 DoubleStruckFour:
   esc-alias: ds4
   has-unicode-inverse: true
@@ -2109,6 +2336,7 @@ DoubleStruckFour:
   unicode-equivalent: "\U0001D7DC"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT FOUR
   wl-unicode: "\uF7DF"
+
 DoubleStruckG:
   esc-alias: dsg
   has-unicode-inverse: true
@@ -2116,6 +2344,7 @@ DoubleStruckG:
   unicode-equivalent: "\U0001D558"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL G
   wl-unicode: "\uF6EC"
+
 DoubleStruckH:
   esc-alias: dsh
   has-unicode-inverse: true
@@ -2123,6 +2352,7 @@ DoubleStruckH:
   unicode-equivalent: "\U0001D559"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL H
   wl-unicode: "\uF6ED"
+
 DoubleStruckI:
   esc-alias: dsi
   has-unicode-inverse: true
@@ -2130,6 +2360,7 @@ DoubleStruckI:
   unicode-equivalent: "\U0001D55A"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL I
   wl-unicode: "\uF6EE"
+
 DoubleStruckJ:
   esc-alias: dsj
   has-unicode-inverse: true
@@ -2137,6 +2368,7 @@ DoubleStruckJ:
   unicode-equivalent: "\U0001D55B"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL J
   wl-unicode: "\uF6EF"
+
 DoubleStruckK:
   esc-alias: dsk
   has-unicode-inverse: true
@@ -2144,6 +2376,7 @@ DoubleStruckK:
   unicode-equivalent: "\U0001D55C"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL K
   wl-unicode: "\uF6F0"
+
 DoubleStruckL:
   esc-alias: dsl
   has-unicode-inverse: true
@@ -2151,6 +2384,7 @@ DoubleStruckL:
   unicode-equivalent: "\U0001D55D"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL L
   wl-unicode: "\uF6F1"
+
 DoubleStruckM:
   esc-alias: dsm
   has-unicode-inverse: true
@@ -2158,6 +2392,7 @@ DoubleStruckM:
   unicode-equivalent: "\U0001D55E"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL M
   wl-unicode: "\uF6F2"
+
 DoubleStruckN:
   esc-alias: dsn
   has-unicode-inverse: true
@@ -2165,6 +2400,7 @@ DoubleStruckN:
   unicode-equivalent: "\U0001D55F"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL N
   wl-unicode: "\uF6F3"
+
 DoubleStruckNine:
   esc-alias: ds9
   has-unicode-inverse: true
@@ -2172,6 +2408,7 @@ DoubleStruckNine:
   unicode-equivalent: "\U0001D7E1"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT NINE
   wl-unicode: "\uF7E4"
+
 DoubleStruckO:
   esc-alias: dso
   has-unicode-inverse: true
@@ -2179,6 +2416,7 @@ DoubleStruckO:
   unicode-equivalent: "\U0001D560"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL O
   wl-unicode: "\uF6F4"
+
 DoubleStruckOne:
   esc-alias: ds1
   has-unicode-inverse: true
@@ -2186,6 +2424,7 @@ DoubleStruckOne:
   unicode-equivalent: "\U0001D7D9"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT ONE
   wl-unicode: "\uF7DC"
+
 DoubleStruckP:
   esc-alias: dsp
   has-unicode-inverse: true
@@ -2193,6 +2432,7 @@ DoubleStruckP:
   unicode-equivalent: "\U0001D561"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL P
   wl-unicode: "\uF6F5"
+
 DoubleStruckQ:
   esc-alias: dsq
   has-unicode-inverse: true
@@ -2200,6 +2440,7 @@ DoubleStruckQ:
   unicode-equivalent: "\U0001D562"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL Q
   wl-unicode: "\uF6F6"
+
 DoubleStruckR:
   esc-alias: dsr
   has-unicode-inverse: true
@@ -2207,6 +2448,7 @@ DoubleStruckR:
   unicode-equivalent: "\U0001D563"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL R
   wl-unicode: "\uF6F7"
+
 DoubleStruckS:
   esc-alias: dss
   has-unicode-inverse: true
@@ -2214,6 +2456,7 @@ DoubleStruckS:
   unicode-equivalent: "\U0001D564"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL S
   wl-unicode: "\uF6F8"
+
 DoubleStruckSeven:
   esc-alias: ds7
   has-unicode-inverse: true
@@ -2221,6 +2464,7 @@ DoubleStruckSeven:
   unicode-equivalent: "\U0001D7DF"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT SEVEN
   wl-unicode: "\uF7E2"
+
 DoubleStruckSix:
   esc-alias: ds6
   has-unicode-inverse: true
@@ -2228,6 +2472,7 @@ DoubleStruckSix:
   unicode-equivalent: "\U0001D7DE"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT SIX
   wl-unicode: "\uF7E1"
+
 DoubleStruckT:
   esc-alias: dst
   has-unicode-inverse: true
@@ -2235,6 +2480,7 @@ DoubleStruckT:
   unicode-equivalent: "\U0001D565"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL T
   wl-unicode: "\uF6F9"
+
 DoubleStruckThree:
   esc-alias: ds3
   has-unicode-inverse: true
@@ -2242,6 +2488,7 @@ DoubleStruckThree:
   unicode-equivalent: "\U0001D7DB"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT THREE
   wl-unicode: "\uF7DE"
+
 DoubleStruckTwo:
   esc-alias: ds2
   has-unicode-inverse: true
@@ -2249,6 +2496,7 @@ DoubleStruckTwo:
   unicode-equivalent: "\U0001D7DA"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT TWO
   wl-unicode: "\uF7DD"
+
 DoubleStruckU:
   esc-alias: dsu
   has-unicode-inverse: true
@@ -2256,6 +2504,7 @@ DoubleStruckU:
   unicode-equivalent: "\U0001D566"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL U
   wl-unicode: "\uF6FA"
+
 DoubleStruckV:
   esc-alias: dsv
   has-unicode-inverse: true
@@ -2263,6 +2512,7 @@ DoubleStruckV:
   unicode-equivalent: "\U0001D567"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL V
   wl-unicode: "\uF6FB"
+
 DoubleStruckW:
   esc-alias: dsw
   has-unicode-inverse: true
@@ -2270,6 +2520,7 @@ DoubleStruckW:
   unicode-equivalent: "\U0001D568"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL W
   wl-unicode: "\uF6FC"
+
 DoubleStruckX:
   esc-alias: dsx
   has-unicode-inverse: true
@@ -2277,6 +2528,7 @@ DoubleStruckX:
   unicode-equivalent: "\U0001D569"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL X
   wl-unicode: "\uF6FD"
+
 DoubleStruckY:
   esc-alias: dsy
   has-unicode-inverse: true
@@ -2284,6 +2536,7 @@ DoubleStruckY:
   unicode-equivalent: "\U0001D56A"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL Y
   wl-unicode: "\uF6FE"
+
 DoubleStruckZ:
   esc-alias: dsz
   has-unicode-inverse: true
@@ -2291,6 +2544,7 @@ DoubleStruckZ:
   unicode-equivalent: "\U0001D56B"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK SMALL Z
   wl-unicode: "\uF6FF"
+
 DoubleStruckZero:
   esc-alias: ds0
   has-unicode-inverse: true
@@ -2298,6 +2552,7 @@ DoubleStruckZero:
   unicode-equivalent: "\U0001D7D8"
   unicode-equivalent-name: MATHEMATICAL DOUBLE-STRUCK DIGIT ZERO
   wl-unicode: "\uF7DB"
+
 DoubleUpArrow:
   amslatex: "\\Uparrow"
   has-unicode-inverse: false
@@ -2307,6 +2562,7 @@ DoubleUpArrow:
   unicode-equivalent-name: UPWARDS DOUBLE ARROW
   wl-unicode: "\u21D1"
   wl-unicode-name: UPWARDS DOUBLE ARROW
+
 DoubleUpDownArrow:
   amslatex: "\\Updownarrow"
   has-unicode-inverse: false
@@ -2316,6 +2572,7 @@ DoubleUpDownArrow:
   unicode-equivalent-name: UP DOWN DOUBLE ARROW
   wl-unicode: "\u21D5"
   wl-unicode-name: UP DOWN DOUBLE ARROW
+
 DoubleVerticalBar:
   amslatex: "\\parallel"
   esc-alias: ' ||'
@@ -2326,6 +2583,7 @@ DoubleVerticalBar:
   unicode-equivalent-name: PARALLEL TO
   wl-unicode: "\u2225"
   wl-unicode-name: PARALLEL TO
+
 DoubledGamma:
   amslatex: "\\mathbb{\\gamma}"
   esc-alias: gg
@@ -2334,6 +2592,7 @@ DoubledGamma:
   unicode-equivalent: "\u213D"
   unicode-equivalent-name: DOUBLE-STRUCK SMALL GAMMA
   wl-unicode: "\uF74A"
+
 DoubledPi:
   amslatex: "\\mathbb{\\pi}"
   esc-alias: pp
@@ -2342,6 +2601,7 @@ DoubledPi:
   unicode-equivalent: "\u213C"
   unicode-equivalent-name: DOUBLE-STRUCK SMALL PI
   wl-unicode: "\uF749"
+
 DownArrow:
   amslatex: "\\downarrow"
   has-unicode-inverse: false
@@ -2351,6 +2611,7 @@ DownArrow:
   unicode-equivalent-name: DOWNWARDS ARROW
   wl-unicode: "\u2193"
   wl-unicode-name: DOWNWARDS ARROW
+
 DownArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2359,6 +2620,7 @@ DownArrowBar:
   unicode-equivalent-name: DOWNWARDS ARROW TO BAR
   wl-unicode: "\u2913"
   wl-unicode-name: DOWNWARDS ARROW TO BAR
+
 DownArrowUpArrow:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2367,6 +2629,7 @@ DownArrowUpArrow:
   unicode-equivalent-name: DOWNWARDS ARROW LEFTWARDS OF UPWARDS ARROW
   wl-unicode: "\u21F5"
   wl-unicode-name: DOWNWARDS ARROW LEFTWARDS OF UPWARDS ARROW
+
 DownBreve:
   esc-alias: dbv
   has-unicode-inverse: true
@@ -2374,6 +2637,7 @@ DownBreve:
   unicode-equivalent: " \u0311"
   unicode-equivalent-name: SPACE + COMBINING INVERTED BREVE
   wl-unicode: "\uF755"
+
 DownExclamation:
   esc-alias: d!
   has-unicode-inverse: false
@@ -2382,6 +2646,7 @@ DownExclamation:
   unicode-equivalent-name: INVERTED EXCLAMATION MARK
   wl-unicode: "\xA1"
   wl-unicode-name: INVERTED EXCLAMATION MARK
+
 DownLeftRightVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2390,6 +2655,7 @@ DownLeftRightVector:
   unicode-equivalent-name: LEFT BARB DOWN RIGHT BARB DOWN HARPOON
   wl-unicode: "\u2950"
   wl-unicode-name: LEFT BARB DOWN RIGHT BARB DOWN HARPOON
+
 DownLeftTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2398,6 +2664,7 @@ DownLeftTeeVector:
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB DOWN FROM BAR
   wl-unicode: "\u295E"
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB DOWN FROM BAR
+
 DownLeftVector:
   amslatex: "\\leftharpoondown"
   has-unicode-inverse: false
@@ -2407,6 +2674,7 @@ DownLeftVector:
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB DOWNWARDS
   wl-unicode: "\u21BD"
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB DOWNWARDS
+
 DownLeftVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2415,6 +2683,7 @@ DownLeftVectorBar:
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB DOWN TO BAR
   wl-unicode: "\u2956"
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB DOWN TO BAR
+
 DownPointer:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2423,6 +2692,7 @@ DownPointer:
   unicode-equivalent-name: BLACK DOWN-POINTING SMALL TRIANGLE
   wl-unicode: "\u25BE"
   wl-unicode-name: BLACK DOWN-POINTING SMALL TRIANGLE
+
 DownQuestion:
   esc-alias: d?
   has-unicode-inverse: false
@@ -2431,6 +2701,7 @@ DownQuestion:
   unicode-equivalent-name: INVERTED QUESTION MARK
   wl-unicode: "\xBF"
   wl-unicode-name: INVERTED QUESTION MARK
+
 DownRightTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2439,6 +2710,7 @@ DownRightTeeVector:
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB DOWN FROM BAR
   wl-unicode: "\u295F"
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB DOWN FROM BAR
+
 DownRightVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2447,6 +2719,7 @@ DownRightVector:
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB DOWNWARDS
   wl-unicode: "\u21C1"
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB DOWNWARDS
+
 DownRightVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2455,6 +2728,7 @@ DownRightVectorBar:
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB DOWN TO BAR
   wl-unicode: "\u2957"
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB DOWN TO BAR
+
 DownTee:
   esc-alias: dT
   has-unicode-inverse: false
@@ -2464,6 +2738,7 @@ DownTee:
   unicode-equivalent-name: DOWN TACK
   wl-unicode: "\u22A4"
   wl-unicode-name: DOWN TACK
+
 DownTeeArrow:
   amslatex: "\\MapsDown"
   has-unicode-inverse: false
@@ -2473,6 +2748,7 @@ DownTeeArrow:
   unicode-equivalent-name: DOWNWARDS ARROW FROM BAR
   wl-unicode: "\u21A7"
   wl-unicode-name: DOWNWARDS ARROW FROM BAR
+
 EAcute:
   amslatex: "\\'{e}"
   esc-alias: e'
@@ -2482,6 +2758,7 @@ EAcute:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH ACUTE
   wl-unicode: "\xE9"
   wl-unicode-name: LATIN SMALL LETTER E WITH ACUTE
+
 EBar:
   amslatex: "\\={e}"
   esc-alias: e-
@@ -2491,6 +2768,7 @@ EBar:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH MACRON
   wl-unicode: "\u0113"
   wl-unicode-name: LATIN SMALL LETTER E WITH MACRON
+
 ECup:
   amslatex: "\\u{e}"
   esc-alias: eu
@@ -2500,6 +2778,7 @@ ECup:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH BREVE
   wl-unicode: "\u0115"
   wl-unicode-name: LATIN SMALL LETTER E WITH BREVE
+
 EDoubleDot:
   esc-alias: e"
   has-unicode-inverse: false
@@ -2508,6 +2787,7 @@ EDoubleDot:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH DIAERESIS
   wl-unicode: "\xEB"
   wl-unicode-name: LATIN SMALL LETTER E WITH DIAERESIS
+
 EGrave:
   amslatex: "\\`{e}"
   esc-alias: e`
@@ -2517,6 +2797,7 @@ EGrave:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH GRAVE
   wl-unicode: "\xE8"
   wl-unicode-name: LATIN SMALL LETTER E WITH GRAVE
+
 EHacek:
   amslatex: "\\v{e}"
   esc-alias: ev
@@ -2526,6 +2807,7 @@ EHacek:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH CARON
   wl-unicode: "\u011B"
   wl-unicode-name: LATIN SMALL LETTER E WITH CARON
+
 EHat:
   esc-alias: e^
   has-unicode-inverse: false
@@ -2534,6 +2816,7 @@ EHat:
   unicode-equivalent-name: LATIN SMALL LETTER E WITH CIRCUMFLEX
   wl-unicode: "\xEA"
   wl-unicode-name: LATIN SMALL LETTER E WITH CIRCUMFLEX
+
 Earth:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2541,6 +2824,7 @@ Earth:
   unicode-equivalent-name: EARTH
   wl-unicode: "\u2641"
   wl-unicode-name: EARTH
+
 EighthNote:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2548,6 +2832,7 @@ EighthNote:
   unicode-equivalent-name: EIGHTH NOTE
   wl-unicode: "\u266A"
   wl-unicode-name: EIGHTH NOTE
+
 Element:
   amslatex: "\\in"
   esc-alias: el
@@ -2558,6 +2843,7 @@ Element:
   unicode-equivalent-name: ELEMENT OF
   wl-unicode: "\u2208"
   wl-unicode-name: ELEMENT OF
+
 Ellipsis:
   amslatex: "$\\dots$"
   esc-alias: '...'
@@ -2567,6 +2853,7 @@ Ellipsis:
   unicode-equivalent-name: HORIZONTAL ELLIPSIS
   wl-unicode: "\u2026"
   wl-unicode-name: HORIZONTAL ELLIPSIS
+
 EmptyCircle:
   esc-alias: eci
   has-unicode-inverse: false
@@ -2575,6 +2862,7 @@ EmptyCircle:
   unicode-equivalent-name: WHITE CIRCLE
   wl-unicode: "\u25CB"
   wl-unicode-name: WHITE CIRCLE
+
 EmptyDiamond:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2582,6 +2870,7 @@ EmptyDiamond:
   unicode-equivalent-name: WHITE DIAMOND
   wl-unicode: "\u25C7"
   wl-unicode-name: WHITE DIAMOND
+
 EmptyDownTriangle:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2589,6 +2878,7 @@ EmptyDownTriangle:
   unicode-equivalent-name: WHITE DOWN-POINTING TRIANGLE
   wl-unicode: "\u25BD"
   wl-unicode-name: WHITE DOWN-POINTING TRIANGLE
+
 EmptyRectangle:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2596,6 +2886,7 @@ EmptyRectangle:
   unicode-equivalent-name: WHITE VERTICAL RECTANGLE
   wl-unicode: "\u25AF"
   wl-unicode-name: WHITE VERTICAL RECTANGLE
+
 EmptySet:
   amslatex: "\\varnothing"
   esc-alias: es
@@ -2605,6 +2896,7 @@ EmptySet:
   unicode-equivalent-name: EMPTY SET
   wl-unicode: "\u2205"
   wl-unicode-name: EMPTY SET
+
 EmptySmallCircle:
   esc-alias: esci
   has-unicode-inverse: false
@@ -2613,6 +2905,7 @@ EmptySmallCircle:
   unicode-equivalent-name: WHITE BULLET
   wl-unicode: "\u25E6"
   wl-unicode-name: WHITE BULLET
+
 EmptySmallSquare:
   esc-alias: essq
   has-unicode-inverse: false
@@ -2621,6 +2914,7 @@ EmptySmallSquare:
   unicode-equivalent-name: WHITE MEDIUM SQUARE
   wl-unicode: "\u25FB"
   wl-unicode-name: WHITE MEDIUM SQUARE
+
 EmptySquare:
   esc-alias: esq
   has-unicode-inverse: false
@@ -2629,6 +2923,7 @@ EmptySquare:
   unicode-equivalent-name: WHITE SQUARE
   wl-unicode: "\u25A1"
   wl-unicode-name: WHITE SQUARE
+
 EmptyUpTriangle:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2636,6 +2931,7 @@ EmptyUpTriangle:
   unicode-equivalent-name: WHITE UP-POINTING TRIANGLE
   wl-unicode: "\u25B3"
   wl-unicode-name: WHITE UP-POINTING TRIANGLE
+
 EmptyVerySmallSquare:
   esc-alias: evssq
   has-unicode-inverse: false
@@ -2644,19 +2940,23 @@ EmptyVerySmallSquare:
   unicode-equivalent-name: WHITE SMALL SQUARE
   wl-unicode: "\u25AB"
   wl-unicode-name: WHITE SMALL SQUARE
+
 EnterKey:
   esc-alias: ent
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF7D4"
+
 EntityEnd:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF3B9"
+
 EntityStart:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF3B8"
+
 Epsilon:
   esc-alias: e
   has-unicode-inverse: false
@@ -2665,6 +2965,7 @@ Epsilon:
   unicode-equivalent-name: GREEK LUNATE EPSILON SYMBOL
   wl-unicode: "\u03F5"
   wl-unicode-name: GREEK LUNATE EPSILON SYMBOL
+
 Equal:
   ascii: "=="
   esc-alias: "=="
@@ -2675,6 +2976,7 @@ Equal:
   unicode-equivalent-name: TWO CONSECUTIVE EQUALS SIGNS
   wl-unicode: "\uF431"
   precedence: 290
+
 EqualTilde:
   esc-alias: =~
   has-unicode-inverse: false
@@ -2684,6 +2986,7 @@ EqualTilde:
   unicode-equivalent-name: MINUS TILDE
   wl-unicode: "\u2242"
   wl-unicode-name: MINUS TILDE
+
 Equilibrium:
   esc-alias: equi
   has-unicode-inverse: false
@@ -2693,6 +2996,7 @@ Equilibrium:
   unicode-equivalent-name: RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON
   wl-unicode: "\u21CC"
   wl-unicode-name: RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON
+
 Equivalent:
   esc-alias: equiv
   has-unicode-inverse: true
@@ -2703,15 +3007,18 @@ Equivalent:
   unicode-equivalent-name: GLEICH STARK
   wl-unicode: "\u29E6"
   wl-unicode-name: GLEICH STARK
+
 ErrorIndicator:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF767"
+
 EscapeKey:
   esc-alias: ' esc'
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF769"
+
 Eta:
   amslatex: "\\eta"
   esc-alias: et
@@ -2721,6 +3028,7 @@ Eta:
   unicode-equivalent-name: GREEK SMALL LETTER ETA
   wl-unicode: "\u03B7"
   wl-unicode-name: GREEK SMALL LETTER ETA
+
 Eth:
   esc-alias: d-
   has-unicode-inverse: false
@@ -2729,6 +3037,7 @@ Eth:
   unicode-equivalent-name: LATIN SMALL LETTER ETH
   wl-unicode: "\xF0"
   wl-unicode-name: LATIN SMALL LETTER ETH
+
 Euro:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2736,6 +3045,7 @@ Euro:
   unicode-equivalent-name: EURO SIGN
   wl-unicode: "\u20AC"
   wl-unicode-name: EURO SIGN
+
 Exists:
   amslatex: "\\exists"
   esc-alias: ex
@@ -2746,6 +3056,7 @@ Exists:
   unicode-equivalent-name: THERE EXISTS
   wl-unicode: "\u2203"
   wl-unicode-name: THERE EXISTS
+
 ExponentialE:
   amslatex: "\\ExponentialE"
   esc-alias: ee
@@ -2773,6 +3084,7 @@ Factorial2:
   is-letter-like: false
   operator-name: Factorial2
   precedence: 610
+
 FiLigature:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2780,6 +3092,7 @@ FiLigature:
   unicode-equivalent-name: LATIN SMALL LIGATURE FI
   wl-unicode: "\uFB01"
   wl-unicode-name: LATIN SMALL LIGATURE FI
+
 FilledCircle:
   esc-alias: fci
   has-unicode-inverse: false
@@ -2788,6 +3101,7 @@ FilledCircle:
   unicode-equivalent-name: BLACK CIRCLE
   wl-unicode: "\u25CF"
   wl-unicode-name: BLACK CIRCLE
+
 FilledDiamond:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2795,6 +3109,7 @@ FilledDiamond:
   unicode-equivalent-name: BLACK DIAMOND
   wl-unicode: "\u25C6"
   wl-unicode-name: BLACK DIAMOND
+
 FilledDownTriangle:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2802,6 +3117,7 @@ FilledDownTriangle:
   unicode-equivalent-name: BLACK DOWN-POINTING TRIANGLE
   wl-unicode: "\u25BC"
   wl-unicode-name: BLACK DOWN-POINTING TRIANGLE
+
 FilledLeftTriangle:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2809,6 +3125,7 @@ FilledLeftTriangle:
   unicode-equivalent-name: BLACK LEFT-POINTING TRIANGLE
   wl-unicode: "\u25C0"
   wl-unicode-name: BLACK LEFT-POINTING TRIANGLE
+
 FilledRectangle:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2816,6 +3133,7 @@ FilledRectangle:
   unicode-equivalent-name: BLACK VERTICAL RECTANGLE
   wl-unicode: "\u25AE"
   wl-unicode-name: BLACK VERTICAL RECTANGLE
+
 FilledRightTriangle:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2823,6 +3141,7 @@ FilledRightTriangle:
   unicode-equivalent-name: BLACK RIGHT-POINTING TRIANGLE
   wl-unicode: "\u25B6"
   wl-unicode-name: BLACK RIGHT-POINTING TRIANGLE
+
 FilledSmallCircle:
   esc-alias: fsci
   has-unicode-inverse: true
@@ -2830,6 +3149,7 @@ FilledSmallCircle:
   unicode-equivalent: "\u2022"
   unicode-equivalent-name: BULLET
   wl-unicode: "\uF750"
+
 FilledSmallSquare:
   esc-alias: fssq
   has-unicode-inverse: false
@@ -2838,6 +3158,7 @@ FilledSmallSquare:
   unicode-equivalent-name: BLACK MEDIUM SQUARE
   wl-unicode: "\u25FC"
   wl-unicode-name: BLACK MEDIUM SQUARE
+
 FilledSquare:
   esc-alias: fsq
   has-unicode-inverse: false
@@ -2846,6 +3167,7 @@ FilledSquare:
   unicode-equivalent-name: BLACK SQUARE
   wl-unicode: "\u25A0"
   wl-unicode-name: BLACK SQUARE
+
 FilledUpTriangle:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2853,6 +3175,7 @@ FilledUpTriangle:
   unicode-equivalent-name: BLACK UP-POINTING TRIANGLE
   wl-unicode: "\u25B2"
   wl-unicode-name: BLACK UP-POINTING TRIANGLE
+
 FilledVerySmallSquare:
   esc-alias: fvssq
   has-unicode-inverse: false
@@ -2861,6 +3184,7 @@ FilledVerySmallSquare:
   unicode-equivalent-name: BLACK SMALL SQUARE
   wl-unicode: "\u25AA"
   wl-unicode-name: BLACK SMALL SQUARE
+
 FinalSigma:
   esc-alias: fs
   has-unicode-inverse: false
@@ -2869,10 +3193,12 @@ FinalSigma:
   unicode-equivalent-name: GREEK SMALL LETTER FINAL SIGMA
   wl-unicode: "\u03C2"
   wl-unicode-name: GREEK SMALL LETTER FINAL SIGMA
+
 FirstPage:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7FA"
+
 FivePointedStar:
   esc-alias: '*5'
   has-unicode-inverse: false
@@ -2881,6 +3207,7 @@ FivePointedStar:
   unicode-equivalent-name: BLACK STAR
   wl-unicode: "\u2605"
   wl-unicode-name: BLACK STAR
+
 FlLigature:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2888,6 +3215,7 @@ FlLigature:
   unicode-equivalent-name: LATIN SMALL LIGATURE FL
   wl-unicode: "\uFB02"
   wl-unicode-name: LATIN SMALL LIGATURE FL
+
 Flat:
   has-unicode-inverse: false
   is-letter-like: true
@@ -2895,6 +3223,7 @@ Flat:
   unicode-equivalent-name: MUSIC FLAT SIGN
   wl-unicode: "\u266D"
   wl-unicode-name: MUSIC FLAT SIGN
+
 Florin:
   has-unicode-inverse: false
   is-letter-like: false
@@ -2902,6 +3231,7 @@ Florin:
   unicode-equivalent-name: LATIN SMALL LETTER F WITH HOOK
   wl-unicode: "\u0192"
   wl-unicode-name: LATIN SMALL LETTER F WITH HOOK
+
 ForAll:
   esc-alias: fa
   has-unicode-inverse: false
@@ -2911,6 +3241,7 @@ ForAll:
   unicode-equivalent-name: FOR ALL
   wl-unicode: "\u2200"
   wl-unicode-name: FOR ALL
+
 FormalA:
   esc-alias: .a
   has-unicode-inverse: true
@@ -2930,6 +3261,7 @@ FormalAlpha:
   unicode-equivalent: "\u03B1\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER ALPHA + COMBINING DOT BELOW
   wl-unicode: "\uF854"
+
 FormalB:
   esc-alias: .b
   has-unicode-inverse: true
@@ -2937,6 +3269,7 @@ FormalB:
   unicode-equivalent: "\u1E05"
   unicode-equivalent-name: LATIN SMALL LETTER B WITH DOT BELOW
   wl-unicode: "\uF801"
+
 FormalBeta:
   esc-alias: .Beta
   has-unicode-inverse: true
@@ -2944,6 +3277,7 @@ FormalBeta:
   unicode-equivalent: "\u03B2\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER BETA + COMBINING DOT BELOW
   wl-unicode: "\uF855"
+
 FormalC:
   esc-alias: .c
   has-unicode-inverse: true
@@ -2951,6 +3285,7 @@ FormalC:
   unicode-equivalent: "c\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER C + COMBINING DOT BELOW
   wl-unicode: "\uF802"
+
 FormalCapitalA:
   esc-alias: .A
   has-unicode-inverse: true
@@ -2958,6 +3293,7 @@ FormalCapitalA:
   unicode-equivalent: "\u1EA0"
   unicode-equivalent-name: LATIN CAPITAL LETTER A WITH DOT BELOW
   wl-unicode: "\uF81A"
+
 FormalCapitalAlpha:
   esc-alias: .CapitalAlpha
   has-unicode-inverse: true
@@ -2965,6 +3301,7 @@ FormalCapitalAlpha:
   unicode-equivalent: "\u0391\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER ALPHA + COMBINING DOT BELOW
   wl-unicode: "\uF834"
+
 FormalCapitalB:
   esc-alias: .B
   has-unicode-inverse: true
@@ -2972,6 +3309,7 @@ FormalCapitalB:
   unicode-equivalent: "\u1E04"
   unicode-equivalent-name: LATIN CAPITAL LETTER B WITH DOT BELOW
   wl-unicode: "\uF81B"
+
 FormalCapitalBeta:
   esc-alias: .CapitalBeta
   has-unicode-inverse: true
@@ -2979,6 +3317,7 @@ FormalCapitalBeta:
   unicode-equivalent: "\u0392\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER BETA + COMBINING DOT BELOW
   wl-unicode: "\uF835"
+
 FormalCapitalC:
   esc-alias: .C
   has-unicode-inverse: false
@@ -2986,6 +3325,7 @@ FormalCapitalC:
   unicode-equivalent: "C\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER C + COMBINING DOT BELOW
   wl-unicode: "\uF81C"
+
 FormalCapitalChi:
   esc-alias: .CapitalChi
   has-unicode-inverse: true
@@ -2993,6 +3333,7 @@ FormalCapitalChi:
   unicode-equivalent: "\u03A7\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER CHI + COMBINING DOT BELOW
   wl-unicode: "\uF84A"
+
 FormalCapitalD:
   esc-alias: .D
   has-unicode-inverse: true
@@ -3000,6 +3341,7 @@ FormalCapitalD:
   unicode-equivalent: "\u1E0C"
   unicode-equivalent-name: LATIN CAPITAL LETTER D WITH DOT BELOW
   wl-unicode: "\uF81D"
+
 FormalCapitalDelta:
   esc-alias: .CapitalDelta
   has-unicode-inverse: true
@@ -3007,6 +3349,7 @@ FormalCapitalDelta:
   unicode-equivalent: "\u0394\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER DELTA + COMBINING DOT BELOW
   wl-unicode: "\uF837"
+
 FormalCapitalDigamma:
   esc-alias: .CapitalDigamma
   has-unicode-inverse: true
@@ -3014,6 +3357,7 @@ FormalCapitalDigamma:
   unicode-equivalent: "\u03DC\u0323"
   unicode-equivalent-name: GREEK LETTER DIGAMMA + COMBINING DOT BELOW
   wl-unicode: "\uF87F"
+
 FormalCapitalE:
   esc-alias: .E
   has-unicode-inverse: true
@@ -3021,6 +3365,7 @@ FormalCapitalE:
   unicode-equivalent: "\u1EB8"
   unicode-equivalent-name: LATIN CAPITAL LETTER E WITH DOT BELOW
   wl-unicode: "\uF81E"
+
 FormalCapitalEpsilon:
   esc-alias: .CapitalEpsilon
   has-unicode-inverse: true
@@ -3028,6 +3373,7 @@ FormalCapitalEpsilon:
   unicode-equivalent: "\u0395\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER EPSILON + COMBINING DOT BELOW
   wl-unicode: "\uF838"
+
 FormalCapitalEta:
   esc-alias: .CapitalEta
   has-unicode-inverse: true
@@ -3035,6 +3381,7 @@ FormalCapitalEta:
   unicode-equivalent: "\u0397\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER ETA + COMBINING DOT BELOW
   wl-unicode: "\uF83A"
+
 FormalCapitalF:
   esc-alias: .F
   has-unicode-inverse: true
@@ -3042,6 +3389,7 @@ FormalCapitalF:
   unicode-equivalent: "F\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER F + COMBINING DOT BELOW
   wl-unicode: "\uF81F"
+
 FormalCapitalG:
   esc-alias: .G
   has-unicode-inverse: true
@@ -3049,6 +3397,7 @@ FormalCapitalG:
   unicode-equivalent: "G\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER G + COMBINING DOT BELOW
   wl-unicode: "\uF820"
+
 FormalCapitalGamma:
   esc-alias: .CapitalGamma
   has-unicode-inverse: true
@@ -3056,6 +3405,7 @@ FormalCapitalGamma:
   unicode-equivalent: "\u0393"
   unicode-equivalent-name: GREEK CAPITAL LETTER GAMMA
   wl-unicode: "\uF836"
+
 FormalCapitalH:
   esc-alias: .H
   has-unicode-inverse: true
@@ -3063,6 +3413,7 @@ FormalCapitalH:
   unicode-equivalent: "\u1E24"
   unicode-equivalent-name: LATIN CAPITAL LETTER H WITH DOT BELOW
   wl-unicode: "\uF821"
+
 FormalCapitalI:
   esc-alias: .I
   has-unicode-inverse: true
@@ -3070,6 +3421,7 @@ FormalCapitalI:
   unicode-equivalent: "\u1ECA"
   unicode-equivalent-name: LATIN CAPITAL LETTER I WITH DOT BELOW
   wl-unicode: "\uF822"
+
 FormalCapitalIota:
   esc-alias: .CapitalIota
   has-unicode-inverse: false
@@ -3077,6 +3429,7 @@ FormalCapitalIota:
   unicode-equivalent: "\u0399\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER IOTA + COMBINING DOT BELOW
   wl-unicode: "\uF83C"
+
 FormalCapitalJ:
   esc-alias: .J
   has-unicode-inverse: true
@@ -3084,6 +3437,7 @@ FormalCapitalJ:
   unicode-equivalent: "J\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER J + COMBINING DOT BELOW
   wl-unicode: "\uF823"
+
 FormalCapitalK:
   esc-alias: .K
   has-unicode-inverse: true
@@ -3091,6 +3445,7 @@ FormalCapitalK:
   unicode-equivalent: "\u1E32"
   unicode-equivalent-name: LATIN CAPITAL LETTER K WITH DOT BELOW
   wl-unicode: "\uF824"
+
 FormalCapitalKappa:
   esc-alias: .CapitalKappa
   has-unicode-inverse: true
@@ -3098,6 +3453,7 @@ FormalCapitalKappa:
   unicode-equivalent: "\u039A\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER KAPPA + COMBINING DOT BELOW
   wl-unicode: "\uF83D"
+
 FormalCapitalKoppa:
   esc-alias: .CapitalKoppa
   has-unicode-inverse: true
@@ -3105,6 +3461,7 @@ FormalCapitalKoppa:
   unicode-equivalent: "\u03DE\u0323"
   unicode-equivalent-name: GREEK LETTER KOPPA + COMBINING DOT BELOW
   wl-unicode: "\uF881"
+
 FormalCapitalL:
   esc-alias: .L
   has-unicode-inverse: true
@@ -3112,6 +3469,7 @@ FormalCapitalL:
   unicode-equivalent: "\u1E36"
   unicode-equivalent-name: LATIN CAPITAL LETTER L WITH DOT BELOW
   wl-unicode: "\uF825"
+
 FormalCapitalLambda:
   esc-alias: .CapitalLambda
   has-unicode-inverse: true
@@ -3119,6 +3477,7 @@ FormalCapitalLambda:
   unicode-equivalent: "\u039B\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER LAMDA + COMBINING DOT BELOW
   wl-unicode: "\uF83E"
+
 FormalCapitalM:
   esc-alias: .M
   has-unicode-inverse: true
@@ -3126,6 +3485,7 @@ FormalCapitalM:
   unicode-equivalent: "\u1E42"
   unicode-equivalent-name: LATIN CAPITAL LETTER M WITH DOT BELOW
   wl-unicode: "\uF826"
+
 FormalCapitalMu:
   esc-alias: .CapitalMu
   has-unicode-inverse: true
@@ -3133,6 +3493,7 @@ FormalCapitalMu:
   unicode-equivalent: "\u039C\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER MU + COMBINING DOT BELOW
   wl-unicode: "\uF83F"
+
 FormalCapitalN:
   esc-alias: .N
   has-unicode-inverse: true
@@ -3140,6 +3501,7 @@ FormalCapitalN:
   unicode-equivalent: "\u1E46"
   unicode-equivalent-name: LATIN CAPITAL LETTER N WITH DOT BELOW
   wl-unicode: "\uF827"
+
 FormalCapitalNu:
   esc-alias: .CapitalNu
   has-unicode-inverse: true
@@ -3147,6 +3509,7 @@ FormalCapitalNu:
   unicode-equivalent: "\u039D\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER NU + COMBINING DOT BELOW
   wl-unicode: "\uF840"
+
 FormalCapitalO:
   esc-alias: .O
   has-unicode-inverse: true
@@ -3154,6 +3517,7 @@ FormalCapitalO:
   unicode-equivalent: "\u1ECC"
   unicode-equivalent-name: LATIN CAPITAL LETTER O WITH DOT BELOW
   wl-unicode: "\uF828"
+
 FormalCapitalOmega:
   esc-alias: .CapitalOmega
   has-unicode-inverse: true
@@ -3161,6 +3525,7 @@ FormalCapitalOmega:
   unicode-equivalent: "\u03A9\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER OMEGA + COMBINING DOT BELOW
   wl-unicode: "\uF84C"
+
 FormalCapitalOmicron:
   esc-alias: .CapitalOmicron
   has-unicode-inverse: true
@@ -3168,6 +3533,7 @@ FormalCapitalOmicron:
   unicode-equivalent: "\u039F\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER OMICRON + COMBINING DOT BELOW
   wl-unicode: "\uF842"
+
 FormalCapitalP:
   esc-alias: .P
   has-unicode-inverse: true
@@ -3175,6 +3541,7 @@ FormalCapitalP:
   unicode-equivalent: "P\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER P + COMBINING DOT BELOW
   wl-unicode: "\uF829"
+
 FormalCapitalPhi:
   esc-alias: .CapitalPhi
   has-unicode-inverse: true
@@ -3182,6 +3549,7 @@ FormalCapitalPhi:
   unicode-equivalent: "\u03A6\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER PHI + COMBINING DOT BELOW
   wl-unicode: "\uF849"
+
 FormalCapitalPi:
   esc-alias: .CapitalPi
   has-unicode-inverse: true
@@ -3189,6 +3557,7 @@ FormalCapitalPi:
   unicode-equivalent: "\u03A0\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER PI + COMBINING DOT BELOW
   wl-unicode: "\uF843"
+
 FormalCapitalPsi:
   esc-alias: .CapitalPsi
   has-unicode-inverse: true
@@ -3196,6 +3565,7 @@ FormalCapitalPsi:
   unicode-equivalent: "\u03A8\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER PSI + COMBINING DOT BELOW
   wl-unicode: "\uF84B"
+
 FormalCapitalQ:
   esc-alias: .Q
   has-unicode-inverse: true
@@ -3203,6 +3573,7 @@ FormalCapitalQ:
   unicode-equivalent: "Q\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER Q + COMBINING DOT BELOW
   wl-unicode: "\uF82A"
+
 FormalCapitalR:
   esc-alias: .R
   has-unicode-inverse: true
@@ -3210,6 +3581,7 @@ FormalCapitalR:
   unicode-equivalent: "\u1E5A"
   unicode-equivalent-name: LATIN CAPITAL LETTER R WITH DOT BELOW
   wl-unicode: "\uF82B"
+
 FormalCapitalRho:
   esc-alias: .CapitalRho
   has-unicode-inverse: true
@@ -3217,6 +3589,7 @@ FormalCapitalRho:
   unicode-equivalent: "\u03A1\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER RHO + COMBINING DOT BELOW
   wl-unicode: "\uF844"
+
 FormalCapitalS:
   esc-alias: .S
   has-unicode-inverse: true
@@ -3224,6 +3597,7 @@ FormalCapitalS:
   unicode-equivalent: "\u1E62"
   unicode-equivalent-name: LATIN CAPITAL LETTER S WITH DOT BELOW
   wl-unicode: "\uF82C"
+
 FormalCapitalSampi:
   esc-alias: .CapitalSampi
   has-unicode-inverse: true
@@ -3231,6 +3605,7 @@ FormalCapitalSampi:
   unicode-equivalent: "\u03E0\u0323"
   unicode-equivalent-name: GREEK LETTER SAMPI + COMBINING DOT BELOW
   wl-unicode: "\uF883"
+
 FormalCapitalSigma:
   esc-alias: .CapitalSigma
   has-unicode-inverse: true
@@ -3238,6 +3613,7 @@ FormalCapitalSigma:
   unicode-equivalent: "\u03A3\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER SIGMA + COMBINING DOT BELOW
   wl-unicode: "\uF846"
+
 FormalCapitalStigma:
   esc-alias: .CapitalStigma
   has-unicode-inverse: true
@@ -3245,6 +3621,7 @@ FormalCapitalStigma:
   unicode-equivalent: "\u03DA\u0323"
   unicode-equivalent-name: GREEK LETTER STIGMA + COMBINING DOT BELOW
   wl-unicode: "\uF87D"
+
 FormalCapitalT:
   esc-alias: .T
   has-unicode-inverse: true
@@ -3252,6 +3629,7 @@ FormalCapitalT:
   unicode-equivalent: "\u1E6C"
   unicode-equivalent-name: LATIN CAPITAL LETTER T WITH DOT BELOW
   wl-unicode: "\uF82D"
+
 FormalCapitalTau:
   esc-alias: .CapitalTau
   has-unicode-inverse: true
@@ -3259,6 +3637,7 @@ FormalCapitalTau:
   unicode-equivalent: "\u03A4\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER TAU + COMBINING DOT BELOW
   wl-unicode: "\uF847"
+
 FormalCapitalTheta:
   esc-alias: .CapitalTheta
   has-unicode-inverse: true
@@ -3266,6 +3645,7 @@ FormalCapitalTheta:
   unicode-equivalent: "\u0398"
   unicode-equivalent-name: GREEK CAPITAL LETTER THETA
   wl-unicode: "\uF83B"
+
 FormalCapitalU:
   esc-alias: .U
   has-unicode-inverse: true
@@ -3273,6 +3653,7 @@ FormalCapitalU:
   unicode-equivalent: "\u1EE4"
   unicode-equivalent-name: LATIN CAPITAL LETTER U WITH DOT BELOW
   wl-unicode: "\uF82E"
+
 FormalCapitalUpsilon:
   esc-alias: .CapitalUpsilon
   has-unicode-inverse: true
@@ -3280,6 +3661,7 @@ FormalCapitalUpsilon:
   unicode-equivalent: "\u03A5\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER UPSILON + COMBINING DOT BELOW
   wl-unicode: "\uF848"
+
 FormalCapitalV:
   esc-alias: .V
   has-unicode-inverse: true
@@ -3287,6 +3669,7 @@ FormalCapitalV:
   unicode-equivalent: "\u1E7E"
   unicode-equivalent-name: LATIN CAPITAL LETTER V WITH DOT BELOW
   wl-unicode: "\uF82F"
+
 FormalCapitalW:
   esc-alias: .W
   has-unicode-inverse: true
@@ -3294,6 +3677,7 @@ FormalCapitalW:
   unicode-equivalent: "\u1E88"
   unicode-equivalent-name: LATIN CAPITAL LETTER W WITH DOT BELOW
   wl-unicode: "\uF830"
+
 FormalCapitalX:
   esc-alias: .X
   has-unicode-inverse: true
@@ -3301,6 +3685,7 @@ FormalCapitalX:
   unicode-equivalent: "X\u0323"
   unicode-equivalent-name: LATIN CAPITAL LETTER X + COMBINING DOT BELOW
   wl-unicode: "\uF831"
+
 FormalCapitalXi:
   esc-alias: .CapitalXi
   has-unicode-inverse: true
@@ -3308,6 +3693,7 @@ FormalCapitalXi:
   unicode-equivalent: "\u039E\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER XI + COMBINING DOT BELOW
   wl-unicode: "\uF841"
+
 FormalCapitalY:
   esc-alias: .Y
   has-unicode-inverse: true
@@ -3315,6 +3701,7 @@ FormalCapitalY:
   unicode-equivalent: "\u1EF4"
   unicode-equivalent-name: LATIN CAPITAL LETTER Y WITH DOT BELOW
   wl-unicode: "\uF832"
+
 FormalCapitalZ:
   esc-alias: .Z
   has-unicode-inverse: true
@@ -3322,6 +3709,7 @@ FormalCapitalZ:
   unicode-equivalent: "\u1E92"
   unicode-equivalent-name: LATIN CAPITAL LETTER Z WITH DOT BELOW
   wl-unicode: "\uF833"
+
 FormalCapitalZeta:
   esc-alias: .CapitalZeta
   has-unicode-inverse: true
@@ -3329,6 +3717,7 @@ FormalCapitalZeta:
   unicode-equivalent: "\u0396\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER ZETA + COMBINING DOT BELOW
   wl-unicode: "\uF839"
+
 FormalChi:
   esc-alias: .Chi
   has-unicode-inverse: true
@@ -3336,6 +3725,7 @@ FormalChi:
   unicode-equivalent: "\u03C7\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER CHI + COMBINING DOT BELOW
   wl-unicode: "\uF86A"
+
 FormalCurlyCapitalUpsilon:
   esc-alias: .CurlyCapitalUpsilon
   has-unicode-inverse: true
@@ -3343,6 +3733,7 @@ FormalCurlyCapitalUpsilon:
   unicode-equivalent: "\u03D2\u0323"
   unicode-equivalent-name: GREEK UPSILON WITH HOOK SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF875"
+
 FormalCurlyEpsilon:
   esc-alias: .CurlyEpsilon
   has-unicode-inverse: true
@@ -3350,6 +3741,7 @@ FormalCurlyEpsilon:
   unicode-equivalent: "\u03B5\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER EPSILON + COMBINING DOT BELOW
   wl-unicode: "\uF858"
+
 FormalCurlyKappa:
   esc-alias: .CurlyKappa
   has-unicode-inverse: true
@@ -3357,6 +3749,7 @@ FormalCurlyKappa:
   unicode-equivalent: "\u03F0\u0323"
   unicode-equivalent-name: GREEK KAPPA SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF885"
+
 FormalCurlyPhi:
   esc-alias: .CurlyPhi
   has-unicode-inverse: true
@@ -3364,6 +3757,7 @@ FormalCurlyPhi:
   unicode-equivalent: "\u03C6\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER PHI + COMBINING DOT BELOW
   wl-unicode: "\uF869"
+
 FormalCurlyPi:
   esc-alias: .CurlyPi
   has-unicode-inverse: true
@@ -3371,6 +3765,7 @@ FormalCurlyPi:
   unicode-equivalent: "\u03D6\u0323"
   unicode-equivalent-name: GREEK PI SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF879"
+
 FormalCurlyRho:
   esc-alias: .CurlyRho
   has-unicode-inverse: true
@@ -3378,6 +3773,7 @@ FormalCurlyRho:
   unicode-equivalent: "\u03F1\u0323"
   unicode-equivalent-name: GREEK RHO SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF886"
+
 FormalCurlyTheta:
   esc-alias: .CurlyTheta
   has-unicode-inverse: true
@@ -3385,6 +3781,7 @@ FormalCurlyTheta:
   unicode-equivalent: "\u03D1\u0323"
   unicode-equivalent-name: GREEK THETA SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF874"
+
 FormalD:
   esc-alias: .d
   has-unicode-inverse: true
@@ -3392,6 +3789,7 @@ FormalD:
   unicode-equivalent: "\u1E0D"
   unicode-equivalent-name: LATIN SMALL LETTER D WITH DOT BELOW
   wl-unicode: "\uF803"
+
 FormalDelta:
   esc-alias: .Delta
   has-unicode-inverse: true
@@ -3399,6 +3797,7 @@ FormalDelta:
   unicode-equivalent: "\u03B4\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER DELTA + COMBINING DOT BELOW
   wl-unicode: "\uF857"
+
 FormalDigamma:
   esc-alias: .Digamma
   has-unicode-inverse: true
@@ -3406,6 +3805,7 @@ FormalDigamma:
   unicode-equivalent: "\u03DD"
   unicode-equivalent-name: GREEK SMALL LETTER DIGAMMA
   wl-unicode: "\uF880"
+
 FormalE:
   esc-alias: .e
   has-unicode-inverse: true
@@ -3413,6 +3813,7 @@ FormalE:
   unicode-equivalent: "\u1EB9"
   unicode-equivalent-name: LATIN SMALL LETTER E WITH DOT BELOW
   wl-unicode: "\uF804"
+
 FormalEpsilon:
   esc-alias: .Epsilon
   has-unicode-inverse: true
@@ -3420,6 +3821,7 @@ FormalEpsilon:
   unicode-equivalent: "\u03F5\u0323"
   unicode-equivalent-name: GREEK LUNATE EPSILON SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF88A"
+
 FormalEta:
   esc-alias: .Eta
   has-unicode-inverse: true
@@ -3427,6 +3829,7 @@ FormalEta:
   unicode-equivalent: "\u03B7\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER ETA + COMBINING DOT BELOW
   wl-unicode: "\uF85A"
+
 FormalF:
   esc-alias: .f
   has-unicode-inverse: true
@@ -3434,6 +3837,7 @@ FormalF:
   unicode-equivalent: "f\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER F + COMBINING DOT BELOW
   wl-unicode: "\uF805"
+
 FormalFinalSigma:
   esc-alias: .FinalSigma
   has-unicode-inverse: true
@@ -3441,6 +3845,7 @@ FormalFinalSigma:
   unicode-equivalent: "\u03C2\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER FINAL SIGMA + COMBINING DOT BELOW
   wl-unicode: "\uF865"
+
 FormalG:
   esc-alias: .g
   has-unicode-inverse: true
@@ -3448,6 +3853,7 @@ FormalG:
   unicode-equivalent: "g\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER G + COMBINING DOT BELOW
   wl-unicode: "\uF806"
+
 FormalGamma:
   amslatex: "$\\gamma$"
   esc-alias: .Gamma
@@ -3456,6 +3862,7 @@ FormalGamma:
   unicode-equivalent: "\u03B3\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER GAMMA + COMBINING DOT BELOW
   wl-unicode: "\uF856"
+
 FormalH:
   esc-alias: .h
   has-unicode-inverse: true
@@ -3463,6 +3870,7 @@ FormalH:
   unicode-equivalent: "\u1E25"
   unicode-equivalent-name: LATIN SMALL LETTER H WITH DOT BELOW
   wl-unicode: "\uF807"
+
 FormalI:
   esc-alias: .i
   has-unicode-inverse: true
@@ -3470,6 +3878,7 @@ FormalI:
   unicode-equivalent: "\u1ECB"
   unicode-equivalent-name: LATIN SMALL LETTER I WITH DOT BELOW
   wl-unicode: "\uF808"
+
 FormalIota:
   esc-alias: .Iota
   has-unicode-inverse: true
@@ -3477,6 +3886,7 @@ FormalIota:
   unicode-equivalent: "\u0399\u0323"
   unicode-equivalent-name: GREEK CAPITAL LETTER IOTA + COMBINING DOT BELOW
   wl-unicode: "\uF85C"
+
 FormalJ:
   esc-alias: .j
   has-unicode-inverse: true
@@ -3484,6 +3894,7 @@ FormalJ:
   unicode-equivalent: "j\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER J + COMBINING DOT BELOW
   wl-unicode: "\uF809"
+
 FormalK:
   esc-alias: .k
   has-unicode-inverse: true
@@ -3491,6 +3902,7 @@ FormalK:
   unicode-equivalent: "\u1E33"
   unicode-equivalent-name: LATIN SMALL LETTER K WITH DOT BELOW
   wl-unicode: "\uF80A"
+
 FormalKappa:
   esc-alias: .Kappa
   has-unicode-inverse: true
@@ -3498,6 +3910,7 @@ FormalKappa:
   unicode-equivalent: "\u03BA\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER KAPPA + COMBINING DOT BELOW
   wl-unicode: "\uF85D"
+
 FormalKoppa:
   esc-alias: .Koppa
   has-unicode-inverse: true
@@ -3505,6 +3918,7 @@ FormalKoppa:
   unicode-equivalent: "\u03DF\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER KOPPA + COMBINING DOT BELOW
   wl-unicode: "\uF882"
+
 FormalL:
   esc-alias: .l
   has-unicode-inverse: true
@@ -3512,6 +3926,7 @@ FormalL:
   unicode-equivalent: "\u1E37"
   unicode-equivalent-name: LATIN SMALL LETTER L WITH DOT BELOW
   wl-unicode: "\uF80B"
+
 FormalLambda:
   esc-alias: .Lambda
   has-unicode-inverse: true
@@ -3519,6 +3934,7 @@ FormalLambda:
   unicode-equivalent: "\u03BB\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER LAMDA + COMBINING DOT BELOW
   wl-unicode: "\uF85E"
+
 FormalM:
   esc-alias: .m
   has-unicode-inverse: true
@@ -3526,6 +3942,7 @@ FormalM:
   unicode-equivalent: "m\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER M + COMBINING DOT BELOW
   wl-unicode: "\uF80C"
+
 FormalMu:
   esc-alias: .Mu
   has-unicode-inverse: true
@@ -3533,6 +3950,7 @@ FormalMu:
   unicode-equivalent: "\u03BC\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER MU + COMBINING DOT BELOW
   wl-unicode: "\uF85F"
+
 FormalN:
   esc-alias: .n
   has-unicode-inverse: true
@@ -3540,6 +3958,7 @@ FormalN:
   unicode-equivalent: "n\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER N + COMBINING DOT BELOW
   wl-unicode: "\uF80D"
+
 FormalNu:
   esc-alias: .Nu
   has-unicode-inverse: true
@@ -3547,6 +3966,7 @@ FormalNu:
   unicode-equivalent: "\u03BD\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER NU + COMBINING DOT BELOW
   wl-unicode: "\uF860"
+
 FormalO:
   esc-alias: .o
   has-unicode-inverse: true
@@ -3554,6 +3974,7 @@ FormalO:
   unicode-equivalent: "o\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER O + COMBINING DOT BELOW
   wl-unicode: "\uF80E"
+
 FormalOmega:
   esc-alias: .Omega
   has-unicode-inverse: true
@@ -3561,6 +3982,7 @@ FormalOmega:
   unicode-equivalent: "\u03C9\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER OMEGA + COMBINING DOT BELOW
   wl-unicode: "\uF86C"
+
 FormalOmicron:
   esc-alias: .Omicron
   has-unicode-inverse: true
@@ -3568,6 +3990,7 @@ FormalOmicron:
   unicode-equivalent: "\u03BF\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER OMICRON + COMBINING DOT BELOW
   wl-unicode: "\uF862"
+
 FormalP:
   esc-alias: .p
   has-unicode-inverse: true
@@ -3575,6 +3998,7 @@ FormalP:
   unicode-equivalent: "p\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER P + COMBINING DOT BELOW
   wl-unicode: "\uF80F"
+
 FormalPhi:
   esc-alias: .Phi
   has-unicode-inverse: true
@@ -3582,6 +4006,7 @@ FormalPhi:
   unicode-equivalent: "\u03D5\u0323"
   unicode-equivalent-name: GREEK PHI SYMBOL + COMBINING DOT BELOW
   wl-unicode: "\uF878"
+
 FormalPi:
   esc-alias: .Pi
   has-unicode-inverse: true
@@ -3589,6 +4014,7 @@ FormalPi:
   unicode-equivalent: "\u03C0\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER PI + COMBINING DOT BELOW
   wl-unicode: "\uF863"
+
 FormalPsi:
   esc-alias: .Psi
   has-unicode-inverse: true
@@ -3596,6 +4022,7 @@ FormalPsi:
   unicode-equivalent: "\u03C8\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER PSI + COMBINING DOT BELOW
   wl-unicode: "\uF86B"
+
 FormalQ:
   esc-alias: .q
   has-unicode-inverse: true
@@ -3603,6 +4030,7 @@ FormalQ:
   unicode-equivalent: "q\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER Q + COMBINING DOT BELOW
   wl-unicode: "\uF810"
+
 FormalR:
   esc-alias: .r
   has-unicode-inverse: true
@@ -3610,6 +4038,7 @@ FormalR:
   unicode-equivalent: "\u1E5B"
   unicode-equivalent-name: LATIN SMALL LETTER R WITH DOT BELOW
   wl-unicode: "\uF811"
+
 FormalRho:
   esc-alias: .Rho
   has-unicode-inverse: true
@@ -3617,6 +4046,7 @@ FormalRho:
   unicode-equivalent: "\u03C1\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER RHO + COMBINING DOT BELOW
   wl-unicode: "\uF864"
+
 FormalS:
   esc-alias: .s
   has-unicode-inverse: true
@@ -3624,6 +4054,7 @@ FormalS:
   unicode-equivalent: "\u1E63"
   unicode-equivalent-name: LATIN SMALL LETTER S WITH DOT BELOW
   wl-unicode: "\uF812"
+
 FormalSampi:
   esc-alias: .Sampi
   has-unicode-inverse: true
@@ -3631,6 +4062,7 @@ FormalSampi:
   unicode-equivalent: "\u03E1\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER SAMPI + COMBINING DOT BELOW
   wl-unicode: "\uF884"
+
 FormalSigma:
   esc-alias: .Sigma
   has-unicode-inverse: true
@@ -3638,6 +4070,7 @@ FormalSigma:
   unicode-equivalent: "\u03C3\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER SIGMA + COMBINING DOT BELOW
   wl-unicode: "\uF866"
+
 FormalStigma:
   esc-alias: .Stigma
   has-unicode-inverse: true
@@ -3645,6 +4078,7 @@ FormalStigma:
   unicode-equivalent: "\u03DB"
   unicode-equivalent-name: GREEK SMALL LETTER STIGMA
   wl-unicode: "\uF87E"
+
 FormalT:
   esc-alias: .t
   has-unicode-inverse: true
@@ -3652,6 +4086,7 @@ FormalT:
   unicode-equivalent: "\u1E6D"
   unicode-equivalent-name: LATIN SMALL LETTER T WITH DOT BELOW
   wl-unicode: "\uF813"
+
 FormalTau:
   esc-alias: .Tau
   has-unicode-inverse: true
@@ -3659,6 +4094,7 @@ FormalTau:
   unicode-equivalent: "\u03C4\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER TAU + COMBINING DOT BELOW
   wl-unicode: "\uF867"
+
 FormalTheta:
   esc-alias: .Theta
   has-unicode-inverse: true
@@ -3666,6 +4102,7 @@ FormalTheta:
   unicode-equivalent: "\u03B8\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER THETA + COMBINING DOT BELOW
   wl-unicode: "\uF85B"
+
 FormalU:
   esc-alias: .u
   has-unicode-inverse: true
@@ -3673,6 +4110,7 @@ FormalU:
   unicode-equivalent: "\u1EE5"
   unicode-equivalent-name: LATIN SMALL LETTER U WITH DOT BELOW
   wl-unicode: "\uF814"
+
 FormalUpsilon:
   esc-alias: .Upsilon
   has-unicode-inverse: true
@@ -3680,6 +4118,7 @@ FormalUpsilon:
   unicode-equivalent: "\u03C5\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER UPSILON + COMBINING DOT BELOW
   wl-unicode: "\uF868"
+
 FormalV:
   esc-alias: .v
   has-unicode-inverse: true
@@ -3687,6 +4126,7 @@ FormalV:
   unicode-equivalent: "\u1E7F"
   unicode-equivalent-name: LATIN SMALL LETTER V WITH DOT BELOW
   wl-unicode: "\uF815"
+
 FormalW:
   esc-alias: .w
   has-unicode-inverse: true
@@ -3694,6 +4134,7 @@ FormalW:
   unicode-equivalent: "\u1E89"
   unicode-equivalent-name: LATIN SMALL LETTER W WITH DOT BELOW
   wl-unicode: "\uF816"
+
 FormalX:
   esc-alias: .x
   has-unicode-inverse: true
@@ -3701,6 +4142,7 @@ FormalX:
   unicode-equivalent: "x\u0323"
   unicode-equivalent-name: LATIN SMALL LETTER X + COMBINING DOT BELOW
   wl-unicode: "\uF817"
+
 FormalXi:
   esc-alias: .Xi
   has-unicode-inverse: true
@@ -3708,6 +4150,7 @@ FormalXi:
   unicode-equivalent: "\u03BE\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER XI + COMBINING DOT BELOW
   wl-unicode: "\uF861"
+
 FormalY:
   esc-alias: .y
   has-unicode-inverse: true
@@ -3715,6 +4158,7 @@ FormalY:
   unicode-equivalent: "\u1EF5"
   unicode-equivalent-name: LATIN SMALL LETTER Y WITH DOT BELOW
   wl-unicode: "\uF818"
+
 FormalZ:
   esc-alias: .z
   has-unicode-inverse: true
@@ -3722,6 +4166,7 @@ FormalZ:
   unicode-equivalent: "\u1E93"
   unicode-equivalent-name: LATIN SMALL LETTER Z WITH DOT BELOW
   wl-unicode: "\uF819"
+
 FormalZeta:
   esc-alias: .Zeta
   has-unicode-inverse: true
@@ -3729,6 +4174,7 @@ FormalZeta:
   unicode-equivalent: "\u03B6\u0323"
   unicode-equivalent-name: GREEK SMALL LETTER ZETA + COMBINING DOT BELOW
   wl-unicode: "\uF859"
+
 FreakedSmiley:
   esc-alias: :-@
   has-unicode-inverse: false
@@ -3747,6 +4193,7 @@ FreakedSmiley:
 # the YAML name doesn't have to match since there is just ASCII for that.
 # Since we use the name Function as the key here, the YAML name for "&" has
 # to be different, since YAML keys need to be unique.
+
 Function:
   amslatex: "\\mathsto"
   ascii: "|->"
@@ -3770,6 +4217,7 @@ FunctionAmpersand:
   is-letter-like: false
   operator-name: Function
   precedence: 90
+
 Gamma:
   esc-alias: g
   has-unicode-inverse: false
@@ -3778,6 +4226,7 @@ Gamma:
   unicode-equivalent-name: GREEK SMALL LETTER GAMMA
   wl-unicode: "\u03B3"
   wl-unicode-name: GREEK SMALL LETTER GAMMA
+
 GeminiSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -3785,12 +4234,14 @@ GeminiSign:
   unicode-equivalent-name: GEMINI
   wl-unicode: "\u264A"
   wl-unicode-name: GEMINI
+
 Get:
   ascii: "<<"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Get
   precedence: 720
+
 Gimel:
   amslatex: "\\gimel"
   esc-alias: gi
@@ -3800,6 +4251,7 @@ Gimel:
   unicode-equivalent-name: GIMEL SYMBOL
   wl-unicode: "\u2137"
   wl-unicode-name: GIMEL SYMBOL
+
 GothicA:
   esc-alias: goa
   has-unicode-inverse: true
@@ -3807,6 +4259,7 @@ GothicA:
   unicode-equivalent: "\U0001D51E"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL A
   wl-unicode: "\uF6CC"
+
 GothicB:
   esc-alias: gob
   has-unicode-inverse: true
@@ -3814,6 +4267,7 @@ GothicB:
   unicode-equivalent: "\U0001D51F"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL B
   wl-unicode: "\uF6CD"
+
 GothicC:
   esc-alias: goc
   has-unicode-inverse: true
@@ -3821,6 +4275,7 @@ GothicC:
   unicode-equivalent: "\U0001D520"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL C
   wl-unicode: "\uF6CE"
+
 GothicCapitalA:
   esc-alias: goA
   has-unicode-inverse: true
@@ -3828,6 +4283,7 @@ GothicCapitalA:
   unicode-equivalent: "\U0001D504"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL A
   wl-unicode: "\uF78A"
+
 GothicCapitalB:
   esc-alias: goB
   has-unicode-inverse: true
@@ -3835,6 +4291,7 @@ GothicCapitalB:
   unicode-equivalent: "\U0001D505"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL B
   wl-unicode: "\uF78B"
+
 GothicCapitalC:
   amslatex: "\\mathfrak{C}"
   esc-alias: goC
@@ -3844,6 +4301,7 @@ GothicCapitalC:
   unicode-equivalent-name: BLACK-LETTER CAPITAL C
   wl-unicode: "\u212D"
   wl-unicode-name: BLACK-LETTER CAPITAL C
+
 GothicCapitalD:
   esc-alias: goD
   has-unicode-inverse: true
@@ -3851,6 +4309,7 @@ GothicCapitalD:
   unicode-equivalent: "\U0001D507"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL D
   wl-unicode: "\uF78D"
+
 GothicCapitalE:
   esc-alias: goE
   has-unicode-inverse: true
@@ -3858,6 +4317,7 @@ GothicCapitalE:
   unicode-equivalent: "\U0001D508"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL E
   wl-unicode: "\uF78E"
+
 GothicCapitalF:
   esc-alias: goF
   has-unicode-inverse: true
@@ -3865,6 +4325,7 @@ GothicCapitalF:
   unicode-equivalent: "\U0001D509"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL F
   wl-unicode: "\uF78F"
+
 GothicCapitalG:
   esc-alias: goG
   has-unicode-inverse: true
@@ -3872,6 +4333,7 @@ GothicCapitalG:
   unicode-equivalent: "\U0001D50A"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL G
   wl-unicode: "\uF790"
+
 GothicCapitalH:
   esc-alias: goH
   has-unicode-inverse: false
@@ -3880,6 +4342,7 @@ GothicCapitalH:
   unicode-equivalent-name: BLACK-LETTER CAPITAL H
   wl-unicode: "\u210C"
   wl-unicode-name: BLACK-LETTER CAPITAL H
+
 GothicCapitalI:
   esc-alias: goI
   has-unicode-inverse: false
@@ -3888,6 +4351,7 @@ GothicCapitalI:
   unicode-equivalent-name: BLACK-LETTER CAPITAL I
   wl-unicode: "\u2111"
   wl-unicode-name: BLACK-LETTER CAPITAL I
+
 GothicCapitalJ:
   esc-alias: goJ
   has-unicode-inverse: true
@@ -3895,6 +4359,7 @@ GothicCapitalJ:
   unicode-equivalent: "\U0001D50D"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL J
   wl-unicode: "\uF793"
+
 GothicCapitalK:
   esc-alias: goK
   has-unicode-inverse: true
@@ -3902,6 +4367,7 @@ GothicCapitalK:
   unicode-equivalent: "\U0001D50E"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL K
   wl-unicode: "\uF794"
+
 GothicCapitalL:
   esc-alias: goL
   has-unicode-inverse: true
@@ -3909,6 +4375,7 @@ GothicCapitalL:
   unicode-equivalent: "\U0001D50F"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL L
   wl-unicode: "\uF795"
+
 GothicCapitalM:
   esc-alias: goM
   has-unicode-inverse: true
@@ -3916,6 +4383,7 @@ GothicCapitalM:
   unicode-equivalent: "\U0001D510"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL M
   wl-unicode: "\uF796"
+
 GothicCapitalN:
   esc-alias: goN
   has-unicode-inverse: true
@@ -3923,6 +4391,7 @@ GothicCapitalN:
   unicode-equivalent: "\U0001D511"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL N
   wl-unicode: "\uF797"
+
 GothicCapitalO:
   esc-alias: goO
   has-unicode-inverse: true
@@ -3930,6 +4399,7 @@ GothicCapitalO:
   unicode-equivalent: "\U0001D512"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL O
   wl-unicode: "\uF798"
+
 GothicCapitalP:
   esc-alias: goP
   has-unicode-inverse: true
@@ -3937,6 +4407,7 @@ GothicCapitalP:
   unicode-equivalent: "\U0001D513"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL P
   wl-unicode: "\uF799"
+
 GothicCapitalQ:
   esc-alias: goQ
   has-unicode-inverse: true
@@ -3944,6 +4415,7 @@ GothicCapitalQ:
   unicode-equivalent: "\U0001D514"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL Q
   wl-unicode: "\uF79A"
+
 GothicCapitalR:
   esc-alias: goR
   has-unicode-inverse: false
@@ -3952,6 +4424,7 @@ GothicCapitalR:
   unicode-equivalent-name: BLACK-LETTER CAPITAL R
   wl-unicode: "\u211C"
   wl-unicode-name: BLACK-LETTER CAPITAL R
+
 GothicCapitalS:
   esc-alias: goS
   has-unicode-inverse: true
@@ -3959,6 +4432,7 @@ GothicCapitalS:
   unicode-equivalent: "\U0001D516"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL S
   wl-unicode: "\uF79C"
+
 GothicCapitalT:
   esc-alias: goT
   has-unicode-inverse: true
@@ -3966,6 +4440,7 @@ GothicCapitalT:
   unicode-equivalent: "\U0001D517"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL T
   wl-unicode: "\uF79D"
+
 GothicCapitalU:
   esc-alias: goU
   has-unicode-inverse: true
@@ -3973,6 +4448,7 @@ GothicCapitalU:
   unicode-equivalent: "\U0001D518"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL U
   wl-unicode: "\uF79E"
+
 GothicCapitalV:
   esc-alias: goV
   has-unicode-inverse: true
@@ -3980,6 +4456,7 @@ GothicCapitalV:
   unicode-equivalent: "\U0001D519"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL V
   wl-unicode: "\uF79F"
+
 GothicCapitalW:
   esc-alias: goW
   has-unicode-inverse: true
@@ -3987,6 +4464,7 @@ GothicCapitalW:
   unicode-equivalent: "\U0001D51A"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL W
   wl-unicode: "\uF7A0"
+
 GothicCapitalX:
   esc-alias: goX
   has-unicode-inverse: true
@@ -3994,6 +4472,7 @@ GothicCapitalX:
   unicode-equivalent: "\U0001D51B"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL X
   wl-unicode: "\uF7A1"
+
 GothicCapitalY:
   esc-alias: goY
   has-unicode-inverse: true
@@ -4001,6 +4480,7 @@ GothicCapitalY:
   unicode-equivalent: "\U0001D51C"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR CAPITAL Y
   wl-unicode: "\uF7A2"
+
 GothicCapitalZ:
   esc-alias: goZ
   has-unicode-inverse: false
@@ -4009,6 +4489,7 @@ GothicCapitalZ:
   unicode-equivalent-name: BLACK-LETTER CAPITAL Z
   wl-unicode: "\u2128"
   wl-unicode-name: BLACK-LETTER CAPITAL Z
+
 GothicD:
   esc-alias: god
   has-unicode-inverse: true
@@ -4016,6 +4497,7 @@ GothicD:
   unicode-equivalent: "\U0001D521"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL D
   wl-unicode: "\uF6CF"
+
 GothicE:
   esc-alias: goe
   has-unicode-inverse: true
@@ -4023,11 +4505,13 @@ GothicE:
   unicode-equivalent: "\U0001D522"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL E
   wl-unicode: "\uF6D0"
+
 GothicEight:
   esc-alias: go8
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7ED"
+
 GothicF:
   esc-alias: gof
   has-unicode-inverse: true
@@ -4035,16 +4519,19 @@ GothicF:
   unicode-equivalent: "\U0001D523"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL F
   wl-unicode: "\uF6D1"
+
 GothicFive:
   esc-alias: go5
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7EA"
+
 GothicFour:
   esc-alias: go4
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7E9"
+
 GothicG:
   esc-alias: gog
   has-unicode-inverse: true
@@ -4052,6 +4539,7 @@ GothicG:
   unicode-equivalent: "\U0001D524"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL G
   wl-unicode: "\uF6D2"
+
 GothicH:
   esc-alias: goh
   has-unicode-inverse: true
@@ -4059,6 +4547,7 @@ GothicH:
   unicode-equivalent: "\U0001D525"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL H
   wl-unicode: "\uF6D3"
+
 GothicI:
   esc-alias: goi
   has-unicode-inverse: true
@@ -4066,6 +4555,7 @@ GothicI:
   unicode-equivalent: "\U0001D526"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL I
   wl-unicode: "\uF6D4"
+
 GothicJ:
   esc-alias: goj
   has-unicode-inverse: true
@@ -4073,6 +4563,7 @@ GothicJ:
   unicode-equivalent: "\U0001D527"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL J
   wl-unicode: "\uF6D5"
+
 GothicK:
   esc-alias: gok
   has-unicode-inverse: true
@@ -4080,6 +4571,7 @@ GothicK:
   unicode-equivalent: "\U0001D528"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL K
   wl-unicode: "\uF6D6"
+
 GothicL:
   esc-alias: gol
   has-unicode-inverse: true
@@ -4087,6 +4579,7 @@ GothicL:
   unicode-equivalent: "\U0001D529"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL L
   wl-unicode: "\uF6D7"
+
 GothicM:
   esc-alias: gom
   has-unicode-inverse: true
@@ -4094,6 +4587,7 @@ GothicM:
   unicode-equivalent: "\U0001D52A"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL M
   wl-unicode: "\uF6D8"
+
 GothicN:
   esc-alias: gon
   has-unicode-inverse: true
@@ -4101,11 +4595,13 @@ GothicN:
   unicode-equivalent: "\U0001D52B"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL N
   wl-unicode: "\uF6D9"
+
 GothicNine:
   esc-alias: go9
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7EF"
+
 GothicO:
   esc-alias: goo
   has-unicode-inverse: true
@@ -4113,11 +4609,13 @@ GothicO:
   unicode-equivalent: "\U0001D52C"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL O
   wl-unicode: "\uF6DA"
+
 GothicOne:
   esc-alias: go1
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7E6"
+
 GothicP:
   esc-alias: gop
   has-unicode-inverse: true
@@ -4125,6 +4623,7 @@ GothicP:
   unicode-equivalent: "\U0001D52D"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL P
   wl-unicode: "\uF6DB"
+
 GothicQ:
   esc-alias: goq
   has-unicode-inverse: true
@@ -4132,6 +4631,7 @@ GothicQ:
   unicode-equivalent: "\U0001D52E"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL Q
   wl-unicode: "\uF6DC"
+
 GothicR:
   esc-alias: gor
   has-unicode-inverse: true
@@ -4139,6 +4639,7 @@ GothicR:
   unicode-equivalent: "\U0001D52F"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL R
   wl-unicode: "\uF6DD"
+
 GothicS:
   esc-alias: gos
   has-unicode-inverse: true
@@ -4146,16 +4647,19 @@ GothicS:
   unicode-equivalent: "\U0001D530"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL S
   wl-unicode: "\uF6DE"
+
 GothicSeven:
   esc-alias: go7
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7EC"
+
 GothicSix:
   esc-alias: go6
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7EB"
+
 GothicT:
   esc-alias: got
   has-unicode-inverse: true
@@ -4163,16 +4667,19 @@ GothicT:
   unicode-equivalent: "\U0001D531"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL T
   wl-unicode: "\uF6DF"
+
 GothicThree:
   esc-alias: go3
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7E8"
+
 GothicTwo:
   esc-alias: go2
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7E7"
+
 GothicU:
   esc-alias: gou
   has-unicode-inverse: true
@@ -4180,6 +4687,7 @@ GothicU:
   unicode-equivalent: "\U0001D532"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL U
   wl-unicode: "\uF6E0"
+
 GothicV:
   esc-alias: gov
   has-unicode-inverse: true
@@ -4187,6 +4695,7 @@ GothicV:
   unicode-equivalent: "\U0001D533"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL V
   wl-unicode: "\uF6E1"
+
 GothicW:
   esc-alias: gow
   has-unicode-inverse: true
@@ -4194,6 +4703,7 @@ GothicW:
   unicode-equivalent: "\U0001D534"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL W
   wl-unicode: "\uF6E2"
+
 GothicX:
   esc-alias: gox
   has-unicode-inverse: true
@@ -4201,6 +4711,7 @@ GothicX:
   unicode-equivalent: "\U0001D535"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL X
   wl-unicode: "\uF6E3"
+
 GothicY:
   esc-alias: goy
   has-unicode-inverse: true
@@ -4208,6 +4719,7 @@ GothicY:
   unicode-equivalent: "\U0001D536"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL Y
   wl-unicode: "\uF6E4"
+
 GothicZ:
   esc-alias: goz
   has-unicode-inverse: true
@@ -4215,11 +4727,13 @@ GothicZ:
   unicode-equivalent: "\U0001D537"
   unicode-equivalent-name: MATHEMATICAL FRAKTUR SMALL Z
   wl-unicode: "\uF6E5"
+
 GothicZero:
   esc-alias: go0
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7E5"
+
 GrayCircle:
   esc-alias: gci
   has-unicode-inverse: true
@@ -4227,6 +4741,7 @@ GrayCircle:
   unicode-equivalent: "\u25CF"
   unicode-equivalent-name: BLACK CIRCLE
   wl-unicode: "\uF753"
+
 GraySquare:
   esc-alias: gsq
   has-unicode-inverse: false
@@ -4234,6 +4749,7 @@ GraySquare:
   unicode-equivalent: "\u25A0"
   unicode-equivalent-name: BLACK SQUARE
   wl-unicode: "\uF752"
+
 GreaterEqual:
   amslatex: "$\\ge$"
   ascii: ">="
@@ -4245,6 +4761,7 @@ GreaterEqual:
   unicode-equivalent-name: GREATER-THAN OR EQUAL TO
   wl-unicode: "\u2265"
   wl-unicode-name: GREATER-THAN OR EQUAL TO
+
 GreaterEqualLess:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4253,6 +4770,7 @@ GreaterEqualLess:
   unicode-equivalent-name: GREATER-THAN EQUAL TO OR LESS-THAN
   wl-unicode: "\u22DB"
   wl-unicode-name: GREATER-THAN EQUAL TO OR LESS-THAN
+
 GreaterFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4261,6 +4779,7 @@ GreaterFullEqual:
   unicode-equivalent-name: GREATER-THAN OVER EQUAL TO
   wl-unicode: "\u2267"
   wl-unicode-name: GREATER-THAN OVER EQUAL TO
+
 GreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4269,6 +4788,7 @@ GreaterGreater:
   unicode-equivalent-name: MUCH GREATER-THAN
   wl-unicode: "\u226B"
   wl-unicode-name: MUCH GREATER-THAN
+
 GreaterLess:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4277,6 +4797,7 @@ GreaterLess:
   unicode-equivalent-name: GREATER-THAN OR LESS-THAN
   wl-unicode: "\u2277"
   wl-unicode-name: GREATER-THAN OR LESS-THAN
+
 GreaterSlantEqual:
   esc-alias: '>/'
   has-unicode-inverse: false
@@ -4286,6 +4807,7 @@ GreaterSlantEqual:
   unicode-equivalent-name: GREATER-THAN OR SLANTED EQUAL TO
   wl-unicode: "\u2A7E"
   wl-unicode-name: GREATER-THAN OR SLANTED EQUAL TO
+
 GreaterTilde:
   esc-alias: '>~'
   has-unicode-inverse: false
@@ -4295,6 +4817,7 @@ GreaterTilde:
   unicode-equivalent-name: GREATER-THAN OR EQUIVALENT TO
   wl-unicode: "\u2273"
   wl-unicode-name: GREATER-THAN OR EQUIVALENT TO
+
 HBar:
   amslatex: "\\hbar"
   esc-alias: hb
@@ -4304,6 +4827,7 @@ HBar:
   unicode-equivalent-name: PLANCK CONSTANT OVER TWO PI
   wl-unicode: "\u210F"
   wl-unicode-name: PLANCK CONSTANT OVER TWO PI
+
 Hacek:
   esc-alias: hck
   has-unicode-inverse: false
@@ -4312,6 +4836,7 @@ Hacek:
   unicode-equivalent-name: CARON
   wl-unicode: "\u02C7"
   wl-unicode-name: CARON
+
 HappySmiley:
   esc-alias: :)
   has-unicode-inverse: false
@@ -4320,6 +4845,7 @@ HappySmiley:
   unicode-equivalent-name: WHITE SMILING FACE
   wl-unicode: "\u263A"
   wl-unicode-name: WHITE SMILING FACE
+
 HeartSuit:
   has-unicode-inverse: false
   is-letter-like: true
@@ -4327,6 +4853,7 @@ HeartSuit:
   unicode-equivalent-name: WHITE HEART SUIT
   wl-unicode: "\u2661"
   wl-unicode-name: WHITE HEART SUIT
+
 HermitianConjugate:
   esc-alias: hc
   has-unicode-inverse: true
@@ -4334,6 +4861,7 @@ HermitianConjugate:
   unicode-equivalent: "\u22B9"
   unicode-equivalent-name: HERMITIAN CONJUGATE MATRIX
   wl-unicode: "\uF3CE"
+
 HorizontalLine:
   esc-alias: hline
   has-unicode-inverse: false
@@ -4342,6 +4870,7 @@ HorizontalLine:
   unicode-equivalent-name: BOX DRAWINGS LIGHT HORIZONTAL
   wl-unicode: "\u2500"
   wl-unicode-name: BOX DRAWINGS LIGHT HORIZONTAL
+
 HumpDownHump:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4350,6 +4879,7 @@ HumpDownHump:
   unicode-equivalent-name: GEOMETRICALLY EQUIVALENT TO
   wl-unicode: "\u224E"
   wl-unicode-name: GEOMETRICALLY EQUIVALENT TO
+
 HumpEqual:
   esc-alias: h=
   has-unicode-inverse: false
@@ -4359,6 +4889,7 @@ HumpEqual:
   unicode-equivalent-name: DIFFERENCE BETWEEN
   wl-unicode: "\u224F"
   wl-unicode-name: DIFFERENCE BETWEEN
+
 Hyphen:
   esc-alias: hy
   has-unicode-inverse: false
@@ -4367,6 +4898,7 @@ Hyphen:
   unicode-equivalent-name: HYPHEN
   wl-unicode: "\u2010"
   wl-unicode-name: HYPHEN
+
 IAcute:
   amslatex: "\\'{i}"
   esc-alias: i'
@@ -4376,6 +4908,7 @@ IAcute:
   unicode-equivalent-name: LATIN SMALL LETTER I WITH ACUTE
   wl-unicode: "\xED"
   wl-unicode-name: LATIN SMALL LETTER I WITH ACUTE
+
 ICup:
   amslatex: "\\u{i}"
   esc-alias: iu
@@ -4385,6 +4918,7 @@ ICup:
   unicode-equivalent-name: LATIN SMALL LETTER I WITH BREVE
   wl-unicode: "\u012D"
   wl-unicode-name: LATIN SMALL LETTER I WITH BREVE
+
 IDoubleDot:
   esc-alias: i"
   has-unicode-inverse: false
@@ -4393,6 +4927,7 @@ IDoubleDot:
   unicode-equivalent-name: LATIN SMALL LETTER I WITH DIAERESIS
   wl-unicode: "\xEF"
   wl-unicode-name: LATIN SMALL LETTER I WITH DIAERESIS
+
 IGrave:
   amslatex: "\\`{i}"
   esc-alias: i`
@@ -4402,6 +4937,7 @@ IGrave:
   unicode-equivalent-name: LATIN SMALL LETTER I WITH GRAVE
   wl-unicode: "\xEC"
   wl-unicode-name: LATIN SMALL LETTER I WITH GRAVE
+
 IHat:
   esc-alias: i^
   has-unicode-inverse: false
@@ -4410,6 +4946,7 @@ IHat:
   unicode-equivalent-name: LATIN SMALL LETTER I WITH CIRCUMFLEX
   wl-unicode: "\xEE"
   wl-unicode-name: LATIN SMALL LETTER I WITH CIRCUMFLEX
+
 ImaginaryI:
   amslatex: "\\ComplexI"
   esc-alias: ii
@@ -4418,6 +4955,7 @@ ImaginaryI:
   unicode-equivalent: "\u2148"
   unicode-equivalent-name: DOUBLE-STRUCK ITALIC SMALL I
   wl-unicode: "\uF74E"
+
 ImaginaryJ:
   amslatex: "\\ComplexJ"
   esc-alias: jj
@@ -4475,8 +5013,6 @@ Infix:
   amslatex: "\\textasciitilde"
   has-unicode-inverse: false
   is-letter-like: false
-# operator-name: Infix
-  unicode-equivalent: "~"
 
 Information:
   ascii: "??"
@@ -4520,12 +5056,14 @@ InvisibleApplication:
   unicode-equivalent: ''
   unicode-equivalent-name: ''
   wl-unicode: "\uF76D"
+
 InvisibleComma:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2063"
   unicode-equivalent-name: INVISIBLE SEPARATOR
   wl-unicode: "\uF765"
+
 InvisiblePostfixScriptBase:
   esc-alias: -i
   has-unicode-inverse: false
@@ -4533,6 +5071,7 @@ InvisiblePostfixScriptBase:
   unicode-equivalent: ''
   unicode-equivalent-name: ''
   wl-unicode: "\uF3B4"
+
 InvisiblePrefixScriptBase:
   esc-alias: i-
   has-unicode-inverse: false
@@ -4540,6 +5079,7 @@ InvisiblePrefixScriptBase:
   unicode-equivalent: ''
   unicode-equivalent-name: ''
   wl-unicode: "\uF3B3"
+
 InvisibleSpace:
   esc-alias: is
   has-unicode-inverse: false
@@ -4547,6 +5087,7 @@ InvisibleSpace:
   unicode-equivalent: ''
   unicode-equivalent-name: ''
   wl-unicode: "\uF360"
+
 InvisibleTimes:
   has-unicode-inverse: true
   is-letter-like: false
@@ -4554,6 +5095,7 @@ InvisibleTimes:
   unicode-equivalent-name: INVISIBLE TIMES
   wl-unicode: "\u2062"
   wl-unicode-name: INVISIBLE TIMES
+
 Iota:
   amslatex: "\\iota"
   esc-alias: i
@@ -4563,6 +5105,7 @@ Iota:
   unicode-equivalent-name: GREEK SMALL LETTER IOTA
   wl-unicode: "\u03B9"
   wl-unicode-name: GREEK SMALL LETTER IOTA
+
 Jupiter:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4570,6 +5113,7 @@ Jupiter:
   unicode-equivalent-name: JUPITER
   wl-unicode: "\u2643"
   wl-unicode-name: JUPITER
+
 Kappa:
   amslatex: "\\kappa"
   esc-alias: k
@@ -4579,10 +5123,12 @@ Kappa:
   unicode-equivalent-name: GREEK SMALL LETTER KAPPA
   wl-unicode: "\u03BA"
   wl-unicode-name: GREEK SMALL LETTER KAPPA
+
 KernelIcon:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF756"
+
 Koppa:
   esc-alias: ko
   has-unicode-inverse: false
@@ -4591,6 +5137,7 @@ Koppa:
   unicode-equivalent-name: GREEK SMALL LETTER KOPPA
   wl-unicode: "\u03DF"
   wl-unicode-name: GREEK SMALL LETTER KOPPA
+
 LSlash:
   amslatex: "\\l{}"
   esc-alias: l/
@@ -4600,6 +5147,7 @@ LSlash:
   unicode-equivalent-name: LATIN SMALL LETTER L WITH STROKE
   wl-unicode: "\u0142"
   wl-unicode-name: LATIN SMALL LETTER L WITH STROKE
+
 Lambda:
   amslatex: "\\lambda"
   esc-alias: l
@@ -4609,10 +5157,12 @@ Lambda:
   unicode-equivalent-name: GREEK SMALL LETTER LAMDA
   wl-unicode: "\u03BB"
   wl-unicode-name: GREEK SMALL LETTER LAMDA
+
 LastPage:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7FB"
+
 LeftAngleBracket:
   esc-alias: <
   has-unicode-inverse: false
@@ -4621,6 +5171,7 @@ LeftAngleBracket:
   unicode-equivalent-name: LEFT-POINTING ANGLE BRACKET
   wl-unicode: "\u2329"
   wl-unicode-name: LEFT-POINTING ANGLE BRACKET
+
 LeftArrow:
   amslatex: "\\leftarrow"
   esc-alias: <-
@@ -4631,6 +5182,7 @@ LeftArrow:
   unicode-equivalent-name: LEFTWARDS ARROW
   wl-unicode: "\u2190"
   wl-unicode-name: LEFTWARDS ARROW
+
 LeftArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4639,6 +5191,7 @@ LeftArrowBar:
   unicode-equivalent-name: LEFTWARDS ARROW TO BAR
   wl-unicode: "\u21E4"
   wl-unicode-name: LEFTWARDS ARROW TO BAR
+
 LeftArrowRightArrow:
   amslatex: "\\leftrightarrows"
   has-unicode-inverse: false
@@ -4648,11 +5201,13 @@ LeftArrowRightArrow:
   unicode-equivalent-name: LEFTWARDS ARROW OVER RIGHTWARDS ARROW
   wl-unicode: "\u21C6"
   wl-unicode-name: LEFTWARDS ARROW OVER RIGHTWARDS ARROW
+
 LeftAssociation:
   esc-alias: <|
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF113"
+
 LeftBracketingBar:
   esc-alias: l|
   has-unicode-inverse: false
@@ -4660,6 +5215,7 @@ LeftBracketingBar:
   unicode-equivalent: '|'
   unicode-equivalent-name: VERTICAL LINE
   wl-unicode: "\uF603"
+
 LeftCeiling:
   esc-alias: lc
   has-unicode-inverse: false
@@ -4669,6 +5225,7 @@ LeftCeiling:
   unicode-equivalent-name: LEFT CEILING
   wl-unicode: "\u2308"
   wl-unicode-name: LEFT CEILING
+
 LeftDoubleBracket:
   esc-alias: '[['
   has-unicode-inverse: false
@@ -4677,6 +5234,7 @@ LeftDoubleBracket:
   unicode-equivalent-name: LEFT WHITE SQUARE BRACKET
   wl-unicode: "\u301A"
   wl-unicode-name: LEFT WHITE SQUARE BRACKET
+
 LeftDoubleBracketingBar:
   esc-alias: l||
   has-unicode-inverse: false
@@ -4684,6 +5242,7 @@ LeftDoubleBracketingBar:
   unicode-equivalent: "\u2016"
   unicode-equivalent-name: DOUBLE VERTICAL LINE
   wl-unicode: "\uF605"
+
 LeftDownTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4692,6 +5251,7 @@ LeftDownTeeVector:
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFT FROM BAR
   wl-unicode: "\u2961"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB LEFT FROM BAR
+
 LeftDownVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4700,6 +5260,7 @@ LeftDownVector:
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFTWARDS
   wl-unicode: "\u21C3"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB LEFTWARDS
+
 LeftDownVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4708,6 +5269,7 @@ LeftDownVectorBar:
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB LEFT TO BAR
   wl-unicode: "\u2959"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB LEFT TO BAR
+
 LeftFloor:
   esc-alias: lf
   has-unicode-inverse: false
@@ -4717,6 +5279,7 @@ LeftFloor:
   unicode-equivalent-name: LEFT FLOOR
   wl-unicode: "\u230A"
   wl-unicode-name: LEFT FLOOR
+
 LeftGuillemet:
   esc-alias: g<<
   has-unicode-inverse: false
@@ -4725,11 +5288,13 @@ LeftGuillemet:
   unicode-equivalent-name: LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
   wl-unicode: "\xAB"
   wl-unicode-name: LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+
 LeftModified:
   esc-alias: '['
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF76B"
+
 LeftPointer:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4738,6 +5303,7 @@ LeftPointer:
   unicode-equivalent-name: BLACK LEFT-POINTING SMALL TRIANGLE
   wl-unicode: "\u25C2"
   wl-unicode-name: BLACK LEFT-POINTING SMALL TRIANGLE
+
 LeftRightArrow:
   amslatex: "\\leftrightarrow"
   esc-alias: <->
@@ -4748,6 +5314,7 @@ LeftRightArrow:
   unicode-equivalent-name: LEFT RIGHT ARROW
   wl-unicode: "\u2194"
   wl-unicode-name: LEFT RIGHT ARROW
+
 LeftRightVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4756,12 +5323,14 @@ LeftRightVector:
   unicode-equivalent-name: LEFT BARB UP RIGHT BARB UP HARPOON
   wl-unicode: "\u294E"
   wl-unicode-name: LEFT BARB UP RIGHT BARB UP HARPOON
+
 LeftSkeleton:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\xAB"
   unicode-equivalent-name: LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
   wl-unicode: "\uF761"
+
 LeftTee:
   esc-alias: lT
   has-unicode-inverse: false
@@ -4771,6 +5340,7 @@ LeftTee:
   unicode-equivalent-name: LEFT TACK
   wl-unicode: "\u22A3"
   wl-unicode-name: LEFT TACK
+
 LeftTeeArrow:
   amslatex: "\\mapsfrom"
   has-unicode-inverse: false
@@ -4780,6 +5350,7 @@ LeftTeeArrow:
   unicode-equivalent-name: LEFTWARDS ARROW FROM BAR
   wl-unicode: "\u21A4"
   wl-unicode-name: LEFTWARDS ARROW FROM BAR
+
 LeftTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4788,6 +5359,7 @@ LeftTeeVector:
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB UP FROM BAR
   wl-unicode: "\u295A"
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB UP FROM BAR
+
 LeftTriangle:
   amslatex: "\\triangleleft"
   has-unicode-inverse: false
@@ -4797,6 +5369,7 @@ LeftTriangle:
   unicode-equivalent-name: NORMAL SUBGROUP OF
   wl-unicode: "\u22B2"
   wl-unicode-name: NORMAL SUBGROUP OF
+
 LeftTriangleBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4805,6 +5378,7 @@ LeftTriangleBar:
   unicode-equivalent-name: LEFT TRIANGLE BESIDE VERTICAL BAR
   wl-unicode: "\u29CF"
   wl-unicode-name: LEFT TRIANGLE BESIDE VERTICAL BAR
+
 LeftTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4813,6 +5387,7 @@ LeftTriangleEqual:
   unicode-equivalent-name: NORMAL SUBGROUP OF OR EQUAL TO
   wl-unicode: "\u22B4"
   wl-unicode-name: NORMAL SUBGROUP OF OR EQUAL TO
+
 LeftUpDownVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4821,6 +5396,7 @@ LeftUpDownVector:
   unicode-equivalent-name: UP BARB LEFT DOWN BARB LEFT HARPOON
   wl-unicode: "\u2951"
   wl-unicode-name: UP BARB LEFT DOWN BARB LEFT HARPOON
+
 LeftUpTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4829,6 +5405,7 @@ LeftUpTeeVector:
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFT FROM BAR
   wl-unicode: "\u2960"
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFT FROM BAR
+
 LeftUpVector:
   amslatex: "\\upharpoonleft"
   has-unicode-inverse: false
@@ -4838,6 +5415,7 @@ LeftUpVector:
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFTWARDS
   wl-unicode: "\u21BF"
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFTWARDS
+
 LeftUpVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4846,6 +5424,7 @@ LeftUpVectorBar:
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB LEFT TO BAR
   wl-unicode: "\u2958"
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFT TO BAR
+
 LeftVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4854,6 +5433,7 @@ LeftVector:
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB UPWARDS
   wl-unicode: "\u21BC"
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB UPWARDS
+
 LeftVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4862,6 +5442,7 @@ LeftVectorBar:
   unicode-equivalent-name: LEFTWARDS HARPOON WITH BARB UP TO BAR
   wl-unicode: "\u2952"
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB UP TO BAR
+
 LeoSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4887,6 +5468,7 @@ LessEqual:
   unicode-equivalent-name: LESS-THAN OR EQUAL TO
   wl-unicode: "\u2264"
   wl-unicode-name: LESS-THAN OR EQUAL TO
+
 LessEqualGreater:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4895,6 +5477,7 @@ LessEqualGreater:
   unicode-equivalent-name: LESS-THAN EQUAL TO OR GREATER-THAN
   wl-unicode: "\u22DA"
   wl-unicode-name: LESS-THAN EQUAL TO OR GREATER-THAN
+
 LessFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4903,6 +5486,7 @@ LessFullEqual:
   unicode-equivalent-name: LESS-THAN OVER EQUAL TO
   wl-unicode: "\u2266"
   wl-unicode-name: LESS-THAN OVER EQUAL TO
+
 LessGreater:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4911,6 +5495,7 @@ LessGreater:
   unicode-equivalent-name: LESS-THAN OR GREATER-THAN
   wl-unicode: "\u2276"
   wl-unicode-name: LESS-THAN OR GREATER-THAN
+
 LessLess:
   has-unicode-inverse: false
   is-letter-like: false
@@ -4919,6 +5504,7 @@ LessLess:
   unicode-equivalent-name: MUCH LESS-THAN
   wl-unicode: "\u226A"
   wl-unicode-name: MUCH LESS-THAN
+
 LessSlantEqual:
   esc-alias: </
   has-unicode-inverse: false
@@ -4928,6 +5514,7 @@ LessSlantEqual:
   unicode-equivalent-name: LESS-THAN OR SLANTED EQUAL TO
   wl-unicode: "\u2A7D"
   wl-unicode-name: LESS-THAN OR SLANTED EQUAL TO
+
 LessTilde:
   esc-alias: <~
   has-unicode-inverse: false
@@ -4937,6 +5524,7 @@ LessTilde:
   unicode-equivalent-name: LESS-THAN OR EQUIVALENT TO
   wl-unicode: "\u2272"
   wl-unicode-name: LESS-THAN OR EQUIVALENT TO
+
 LetterSpace:
   esc-alias: _
   has-unicode-inverse: false
@@ -4950,6 +5538,7 @@ LibraSign:
   unicode-equivalent-name: LIBRA
   wl-unicode: "\u264E"
   wl-unicode-name: LIBRA
+
 LightBulb:
   has-unicode-inverse: false
   is-letter-like: true
@@ -4982,6 +5571,7 @@ LongLeftArrow:
   unicode-equivalent-name: LONG LEFTWARDS ARROW
   wl-unicode: "\u27F5"
   wl-unicode-name: LONG LEFTWARDS ARROW
+
 LongLeftRightArrow:
   esc-alias: <-->
   has-unicode-inverse: false
@@ -4991,6 +5581,7 @@ LongLeftRightArrow:
   unicode-equivalent-name: LONG LEFT RIGHT ARROW
   wl-unicode: "\u27F7"
   wl-unicode-name: LONG LEFT RIGHT ARROW
+
 LongRightArrow:
   esc-alias: -->
   has-unicode-inverse: false
@@ -5000,6 +5591,7 @@ LongRightArrow:
   unicode-equivalent-name: LONG RIGHTWARDS ARROW
   wl-unicode: "\u27F6"
   wl-unicode-name: LONG RIGHTWARDS ARROW
+
 LowerLeftArrow:
   amslatex: "\\swarrow"
   has-unicode-inverse: false
@@ -5009,6 +5601,7 @@ LowerLeftArrow:
   unicode-equivalent-name: SOUTH WEST ARROW
   wl-unicode: "\u2199"
   wl-unicode-name: SOUTH WEST ARROW
+
 LowerRightArrow:
   amslatex: "\\searrow"
   has-unicode-inverse: false
@@ -5031,6 +5624,7 @@ MapAll:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: MapAll
+
 Mars:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5038,11 +5632,13 @@ Mars:
   unicode-equivalent-name: MALE SIGN
   wl-unicode: "\u2642"
   wl-unicode-name: MALE SIGN
+
 MathematicaIcon:
   esc-alias: math
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF757"
+
 MeasuredAngle:
   amslatex: "\\measuredangle"
   has-unicode-inverse: false
@@ -5051,11 +5647,13 @@ MeasuredAngle:
   unicode-equivalent-name: MEASURED ANGLE
   wl-unicode: "\u2221"
   wl-unicode-name: MEASURED ANGLE
+
 MediumSpace:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\u205F"
   wl-unicode-name: MEDIUM MATHEMATICAL SPACE
+
 Mercury:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5063,12 +5661,14 @@ Mercury:
   unicode-equivalent-name: MERCURY
   wl-unicode: "\u263F"
   wl-unicode-name: MERCURY
+
 Message:
   ascii: "::"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Message
   precedence: 750
+
 Mho:
   esc-alias: mho
   has-unicode-inverse: false
@@ -5077,6 +5677,7 @@ Mho:
   unicode-equivalent-name: INVERTED OHM SIGN
   wl-unicode: "\u2127"
   wl-unicode-name: INVERTED OHM SIGN
+
 Micro:
   esc-alias: mi
   has-unicode-inverse: false
@@ -5102,6 +5703,7 @@ MinusPlus:
   unicode-equivalent-name: MINUS-OR-PLUS SIGN
   wl-unicode: "\u2213"
   wl-unicode-name: MINUS-OR-PLUS SIGN
+
 Mu:
   amslatex: "$\\mu$"
   esc-alias: m
@@ -5111,6 +5713,7 @@ Mu:
   unicode-equivalent-name: GREEK SMALL LETTER MU
   wl-unicode: "\u03BC"
   wl-unicode-name: GREEK SMALL LETTER MU
+
 NHacek:
   amslatex: "\\v{n}"
   esc-alias: nv
@@ -5120,6 +5723,7 @@ NHacek:
   unicode-equivalent-name: LATIN SMALL LETTER N WITH CARON
   wl-unicode: "\u0148"
   wl-unicode-name: LATIN SMALL LETTER N WITH CARON
+
 NTilde:
   esc-alias: n~
   has-unicode-inverse: false
@@ -5128,6 +5732,7 @@ NTilde:
   unicode-equivalent-name: LATIN SMALL LETTER N WITH TILDE
   wl-unicode: "\xF1"
   wl-unicode-name: LATIN SMALL LETTER N WITH TILDE
+
 Nand:
   amslatex: "$\\barwedge$"
   esc-alias: nand
@@ -5137,6 +5742,7 @@ Nand:
   unicode-equivalent-name: NAND
   wl-unicode: "\u22BC"
   wl-unicode-name: NAND
+
 Natural:
   has-unicode-inverse: false
   is-letter-like: true
@@ -5144,26 +5750,31 @@ Natural:
   unicode-equivalent-name: MUSIC NATURAL SIGN
   wl-unicode: "\u266E"
   wl-unicode-name: MUSIC NATURAL SIGN
+
 NegativeMediumSpace:
   esc-alias: '-   '
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF383"
+
 NegativeThickSpace:
   esc-alias: '-    '
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF384"
+
 NegativeThinSpace:
   esc-alias: '-  '
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF382"
+
 NegativeVeryThinSpace:
   esc-alias: '- '
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF380"
+
 Neptune:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5171,6 +5782,7 @@ Neptune:
   unicode-equivalent-name: NEPTUNE
   wl-unicode: "\u2646"
   wl-unicode-name: NEPTUNE
+
 NestedGreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5179,6 +5791,7 @@ NestedGreaterGreater:
   unicode-equivalent-name: DOUBLE NESTED GREATER-THAN
   wl-unicode: "\u2AA2"
   wl-unicode-name: DOUBLE NESTED GREATER-THAN
+
 NestedLessLess:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5187,28 +5800,33 @@ NestedLessLess:
   unicode-equivalent-name: DOUBLE NESTED LESS-THAN
   wl-unicode: "\u2AA1"
   wl-unicode-name: DOUBLE NESTED LESS-THAN
+
 NeutralSmiley:
   esc-alias: :-|
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF722"
+
 NewLine:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u000A"
   wl-unicode: "\u000A"
+
 NoBreak:
   esc-alias: nb
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\u2060"
   wl-unicode-name: WORD JOINER
+
 NonBreakingSpace:
   esc-alias: nbs
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\_"
   wl-unicode-name: NO-BREAK SPACE
+
 NonCommutativeMultiply:
   ascii: "**"
   has-unicode-inverse: false
@@ -5238,6 +5856,7 @@ Not:
   precedence: 230
   wl-unicode: "\00AC"
   wl-unicode-name: NOT SIGN
+
 NotCongruent:
   esc-alias: '!==='
   has-unicode-inverse: false
@@ -5247,6 +5866,7 @@ NotCongruent:
   unicode-equivalent-name: NOT IDENTICAL TO
   wl-unicode: "\u2262"
   wl-unicode-name: NOT IDENTICAL TO
+
 NotCupCap:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5255,6 +5875,7 @@ NotCupCap:
   unicode-equivalent-name: NOT EQUIVALENT TO
   wl-unicode: "\u226D"
   wl-unicode-name: NOT EQUIVALENT TO
+
 NotDoubleVerticalBar:
   amslatex: "\\unparallel"
   esc-alias: '!||'
@@ -5265,6 +5886,7 @@ NotDoubleVerticalBar:
   unicode-equivalent-name: NOT PARALLEL TO
   wl-unicode: "\u2226"
   wl-unicode-name: NOT PARALLEL TO
+
 NotElement:
   amslatex: "\\notin"
   esc-alias: '!el'
@@ -5275,6 +5897,7 @@ NotElement:
   unicode-equivalent-name: NOT AN ELEMENT OF
   wl-unicode: "\u2209"
   wl-unicode-name: NOT AN ELEMENT OF
+
 NotEqual:
   amslatex: "$\ne$"
   ascii: "!="
@@ -5287,11 +5910,13 @@ NotEqual:
   wl-unicode: "\u2260"
   wl-unicode-name: NOT EQUAL TO
   precedence: 290
+
 NotEqualTilde:
   esc-alias: '!=~'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF400"
+
 NotExists:
   amslatex: "\\nexists"
   esc-alias: '!ex'
@@ -5302,6 +5927,7 @@ NotExists:
   unicode-equivalent-name: THERE DOES NOT EXIST
   wl-unicode: "\u2204"
   wl-unicode-name: THERE DOES NOT EXIST
+
 NotGreater:
   esc-alias: '!>'
   has-unicode-inverse: false
@@ -5311,6 +5937,7 @@ NotGreater:
   unicode-equivalent-name: NOT GREATER-THAN
   wl-unicode: "\u226F"
   wl-unicode-name: NOT GREATER-THAN
+
 NotGreaterEqual:
   esc-alias: '!>='
   has-unicode-inverse: false
@@ -5320,6 +5947,7 @@ NotGreaterEqual:
   unicode-equivalent-name: NEITHER GREATER-THAN NOR EQUAL TO
   wl-unicode: "\u2271"
   wl-unicode-name: NEITHER GREATER-THAN NOR EQUAL TO
+
 NotGreaterFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5328,11 +5956,13 @@ NotGreaterFullEqual:
   unicode-equivalent-name: GREATER-THAN BUT NOT EQUAL TO
   wl-unicode: "\u2269"
   wl-unicode-name: GREATER-THAN BUT NOT EQUAL TO
+
 NotGreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotGreaterGreater
   wl-unicode: "\uF427"
+
 NotGreaterLess:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5341,11 +5971,13 @@ NotGreaterLess:
   unicode-equivalent-name: NEITHER GREATER-THAN NOR LESS-THAN
   wl-unicode: "\u2279"
   wl-unicode-name: NEITHER GREATER-THAN NOR LESS-THAN
+
 NotGreaterSlantEqual:
   esc-alias: '!>/'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF429"
+
 NotGreaterTilde:
   esc-alias: '!>~'
   has-unicode-inverse: false
@@ -5355,15 +5987,18 @@ NotGreaterTilde:
   unicode-equivalent-name: NEITHER GREATER-THAN NOR EQUIVALENT TO
   wl-unicode: "\u2275"
   wl-unicode-name: NEITHER GREATER-THAN NOR EQUIVALENT TO
+
 NotHumpDownHump:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF402"
+
 NotHumpEqual:
   esc-alias: '!h='
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF401"
+
 NotLeftTriangle:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5372,10 +6007,12 @@ NotLeftTriangle:
   unicode-equivalent-name: NOT NORMAL SUBGROUP OF
   wl-unicode: "\u22EA"
   wl-unicode-name: NOT NORMAL SUBGROUP OF
+
 NotLeftTriangleBar:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF412"
+
 NotLeftTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5384,6 +6021,7 @@ NotLeftTriangleEqual:
   unicode-equivalent-name: NOT NORMAL SUBGROUP OF OR EQUAL TO
   wl-unicode: "\u22EC"
   wl-unicode-name: NOT NORMAL SUBGROUP OF OR EQUAL TO
+
 NotLess:
   esc-alias: '!<'
   has-unicode-inverse: false
@@ -5393,6 +6031,7 @@ NotLess:
   unicode-equivalent-name: NOT LESS-THAN
   wl-unicode: "\u226E"
   wl-unicode-name: NOT LESS-THAN
+
 NotLessEqual:
   esc-alias: '!<='
   has-unicode-inverse: false
@@ -5402,6 +6041,7 @@ NotLessEqual:
   unicode-equivalent-name: NEITHER LESS-THAN NOR EQUAL TO
   wl-unicode: "\u2270"
   wl-unicode-name: NEITHER LESS-THAN NOR EQUAL TO
+
 NotLessFullEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5410,6 +6050,7 @@ NotLessFullEqual:
   unicode-equivalent-name: LESS-THAN BUT NOT EQUAL TO
   wl-unicode: "\u2268"
   wl-unicode-name: LESS-THAN BUT NOT EQUAL TO
+
 NotLessGreater:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5418,15 +6059,18 @@ NotLessGreater:
   unicode-equivalent-name: NEITHER LESS-THAN NOR GREATER-THAN
   wl-unicode: "\u2278"
   wl-unicode-name: NEITHER LESS-THAN NOR GREATER-THAN
+
 NotLessLess:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF422"
+
 NotLessSlantEqual:
   esc-alias: '!</'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF424"
+
 NotLessTilde:
   esc-alias: '!<~'
   has-unicode-inverse: false
@@ -5436,14 +6080,17 @@ NotLessTilde:
   unicode-equivalent-name: NEITHER LESS-THAN NOR EQUIVALENT TO
   wl-unicode: "\u2274"
   wl-unicode-name: NEITHER LESS-THAN NOR EQUIVALENT TO
+
 NotNestedGreaterGreater:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF428"
+
 NotNestedLessLess:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF423"
+
 NotPrecedes:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5452,10 +6099,12 @@ NotPrecedes:
   unicode-equivalent-name: DOES NOT PRECEDE
   wl-unicode: "\u2280"
   wl-unicode-name: DOES NOT PRECEDE
+
 NotPrecedesEqual:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF42B"
+
 NotPrecedesSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5464,6 +6113,7 @@ NotPrecedesSlantEqual:
   unicode-equivalent-name: DOES NOT PRECEDE OR EQUAL
   wl-unicode: "\u22E0"
   wl-unicode-name: DOES NOT PRECEDE OR EQUAL
+
 NotPrecedesTilde:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5472,6 +6122,7 @@ NotPrecedesTilde:
   unicode-equivalent-name: PRECEDES BUT NOT EQUIVALENT TO
   wl-unicode: "\u22E8"
   wl-unicode-name: PRECEDES BUT NOT EQUIVALENT TO
+
 NotReverseElement:
   amslatex: "\\nni"
   esc-alias: '!mem'
@@ -5482,6 +6133,7 @@ NotReverseElement:
   unicode-equivalent-name: DOES NOT CONTAIN AS MEMBER
   wl-unicode: "\u220C"
   wl-unicode-name: DOES NOT CONTAIN AS MEMBER
+
 NotRightTriangle:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5490,10 +6142,12 @@ NotRightTriangle:
   unicode-equivalent-name: DOES NOT CONTAIN AS NORMAL SUBGROUP
   wl-unicode: "\u22EB"
   wl-unicode-name: DOES NOT CONTAIN AS NORMAL SUBGROUP
+
 NotRightTriangleBar:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF413"
+
 NotRightTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5502,10 +6156,12 @@ NotRightTriangleEqual:
   unicode-equivalent-name: DOES NOT CONTAIN AS NORMAL SUBGROUP OR EQUAL
   wl-unicode: "\u22ED"
   wl-unicode-name: DOES NOT CONTAIN AS NORMAL SUBGROUP OR EQUAL
+
 NotSquareSubset:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF42E"
+
 NotSquareSubsetEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5514,10 +6170,12 @@ NotSquareSubsetEqual:
   unicode-equivalent-name: NOT SQUARE IMAGE OF OR EQUAL TO
   wl-unicode: "\u22E2"
   wl-unicode-name: NOT SQUARE IMAGE OF OR EQUAL TO
+
 NotSquareSuperset:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF42F"
+
 NotSquareSupersetEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5526,6 +6184,7 @@ NotSquareSupersetEqual:
   unicode-equivalent-name: NOT SQUARE ORIGINAL OF OR EQUAL TO
   wl-unicode: "\u22E3"
   wl-unicode-name: NOT SQUARE ORIGINAL OF OR EQUAL TO
+
 NotSubset:
   esc-alias: '!sub'
   has-unicode-inverse: false
@@ -5535,6 +6194,7 @@ NotSubset:
   unicode-equivalent-name: NOT A SUBSET OF
   wl-unicode: "\u2284"
   wl-unicode-name: NOT A SUBSET OF
+
 NotSubsetEqual:
   esc-alias: '!sub='
   has-unicode-inverse: false
@@ -5544,6 +6204,7 @@ NotSubsetEqual:
   unicode-equivalent-name: NEITHER A SUBSET OF NOR EQUAL TO
   wl-unicode: "\u2288"
   wl-unicode-name: NEITHER A SUBSET OF NOR EQUAL TO
+
 NotSucceeds:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5552,10 +6213,12 @@ NotSucceeds:
   unicode-equivalent-name: DOES NOT SUCCEED
   wl-unicode: "\u2281"
   wl-unicode-name: DOES NOT SUCCEED
+
 NotSucceedsEqual:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF42D"
+
 NotSucceedsSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5564,6 +6227,7 @@ NotSucceedsSlantEqual:
   unicode-equivalent-name: DOES NOT SUCCEED OR EQUAL
   wl-unicode: "\u22E1"
   wl-unicode-name: DOES NOT SUCCEED OR EQUAL
+
 NotSucceedsTilde:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5572,6 +6236,7 @@ NotSucceedsTilde:
   unicode-equivalent-name: SUCCEEDS BUT NOT EQUIVALENT TO
   wl-unicode: "\u22E9"
   wl-unicode-name: SUCCEEDS BUT NOT EQUIVALENT TO
+
 NotSuperset:
   esc-alias: '!sup'
   has-unicode-inverse: false
@@ -5581,6 +6246,7 @@ NotSuperset:
   unicode-equivalent-name: NOT A SUPERSET OF
   wl-unicode: "\u2285"
   wl-unicode-name: NOT A SUPERSET OF
+
 NotSupersetEqual:
   esc-alias: '!sup='
   has-unicode-inverse: false
@@ -5590,6 +6256,7 @@ NotSupersetEqual:
   unicode-equivalent-name: NEITHER A SUPERSET OF NOR EQUAL TO
   wl-unicode: "\u2289"
   wl-unicode-name: NEITHER A SUPERSET OF NOR EQUAL TO
+
 NotTilde:
   esc-alias: '!~'
   has-unicode-inverse: false
@@ -5599,6 +6266,7 @@ NotTilde:
   unicode-equivalent-name: NOT TILDE
   wl-unicode: "\u2241"
   wl-unicode-name: NOT TILDE
+
 NotTildeEqual:
   esc-alias: '!~='
   has-unicode-inverse: false
@@ -5608,6 +6276,7 @@ NotTildeEqual:
   unicode-equivalent-name: NOT ASYMPTOTICALLY EQUAL TO
   wl-unicode: "\u2244"
   wl-unicode-name: NOT ASYMPTOTICALLY EQUAL TO
+
 NotTildeFullEqual:
   esc-alias: '!~=='
   has-unicode-inverse: false
@@ -5617,6 +6286,7 @@ NotTildeFullEqual:
   unicode-equivalent-name: NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
   wl-unicode: "\u2247"
   wl-unicode-name: NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
+
 NotTildeTilde:
   esc-alias: '!~~'
   has-unicode-inverse: false
@@ -5626,11 +6296,13 @@ NotTildeTilde:
   unicode-equivalent-name: NOT ALMOST EQUAL TO
   wl-unicode: "\u2249"
   wl-unicode-name: NOT ALMOST EQUAL TO
+
 NotVerticalBar:
   esc-alias: '!|'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3D1"
+
 Nu:
   amslatex: "\\nu"
   esc-alias: n
@@ -5664,6 +6336,7 @@ OAcute:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH ACUTE
   wl-unicode: "\xF3"
   wl-unicode-name: LATIN SMALL LETTER O WITH ACUTE
+
 ODoubleAcute:
   esc-alias: o''
   has-unicode-inverse: false
@@ -5672,6 +6345,7 @@ ODoubleAcute:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH DOUBLE ACUTE
   wl-unicode: "\u0151"
   wl-unicode-name: LATIN SMALL LETTER O WITH DOUBLE ACUTE
+
 ODoubleDot:
   esc-alias: o"
   has-unicode-inverse: false
@@ -5680,6 +6354,7 @@ ODoubleDot:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH DIAERESIS
   wl-unicode: "\xF6"
   wl-unicode-name: LATIN SMALL LETTER O WITH DIAERESIS
+
 OE:
   esc-alias: oe
   has-unicode-inverse: false
@@ -5688,6 +6363,7 @@ OE:
   unicode-equivalent-name: LATIN SMALL LIGATURE OE
   wl-unicode: "\u0153"
   wl-unicode-name: LATIN SMALL LIGATURE OE
+
 OGrave:
   amslatex: "\\`{o}"
   esc-alias: o`
@@ -5697,6 +6373,7 @@ OGrave:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH GRAVE
   wl-unicode: "\xF2"
   wl-unicode-name: LATIN SMALL LETTER O WITH GRAVE
+
 OHat:
   amslatex: "\\^{o}"
   esc-alias: o^
@@ -5706,6 +6383,7 @@ OHat:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH CIRCUMFLEX
   wl-unicode: "\xF4"
   wl-unicode-name: LATIN SMALL LETTER O WITH CIRCUMFLEX
+
 OSlash:
   amslatex: "\\o{}"
   esc-alias: o/
@@ -5715,6 +6393,7 @@ OSlash:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH STROKE
   wl-unicode: "\xF8"
   wl-unicode-name: LATIN SMALL LETTER O WITH STROKE
+
 OTilde:
   esc-alias: o~
   has-unicode-inverse: false
@@ -5723,6 +6402,7 @@ OTilde:
   unicode-equivalent-name: LATIN SMALL LETTER O WITH TILDE
   wl-unicode: "\xF5"
   wl-unicode-name: LATIN SMALL LETTER O WITH TILDE
+
 Omega:
   amslatex: "\\omega"
   esc-alias: o
@@ -5732,6 +6412,7 @@ Omega:
   unicode-equivalent-name: GREEK SMALL LETTER OMEGA
   wl-unicode: "\u03C9"
   wl-unicode-name: GREEK SMALL LETTER OMEGA
+
 Omicron:
   esc-alias: om
   has-unicode-inverse: false
@@ -5740,6 +6421,7 @@ Omicron:
   unicode-equivalent-name: GREEK SMALL LETTER OMICRON
   wl-unicode: "\u03BF"
   wl-unicode-name: GREEK SMALL LETTER OMICRON
+
 OpenCurlyDoubleQuote:
   esc-alias: '["'
   has-unicode-inverse: false
@@ -5748,6 +6430,7 @@ OpenCurlyDoubleQuote:
   unicode-equivalent-name: LEFT DOUBLE QUOTATION MARK
   wl-unicode: "\u201C"
   wl-unicode-name: LEFT DOUBLE QUOTATION MARK
+
 OpenCurlyQuote:
   esc-alias: '['''
   has-unicode-inverse: false
@@ -5796,6 +6479,7 @@ OverBracket:
   unicode-equivalent-name: TOP SQUARE BRACKET
   wl-unicode: "\u23B4"
   wl-unicode-name: TOP SQUARE BRACKET
+
 OverParenthesis:
   esc-alias: o(
   has-unicode-inverse: false
@@ -5804,6 +6488,7 @@ OverParenthesis:
   unicode-equivalent-name: PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
   wl-unicode: "\uFE35"
   wl-unicode-name: PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
+
 Paragraph:
   has-unicode-inverse: false
   is-letter-like: true
@@ -5838,6 +6523,7 @@ PermutationProduct:
   unicode-equivalent: "\u2299"
   unicode-equivalent-name: CIRCLED DOT OPERATOR
   wl-unicode: "\uF3DE"
+
 Perpendicular:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5845,6 +6531,7 @@ Perpendicular:
   unicode-equivalent-name: PERPENDICULAR
   wl-unicode: "\u27C2"
   wl-unicode-name: PERPENDICULAR
+
 Phi:
   amslatex: "\\phi"
   esc-alias: ph
@@ -5854,6 +6541,7 @@ Phi:
   unicode-equivalent-name: GREEK PHI SYMBOL
   wl-unicode: "\u03D5"
   wl-unicode-name: GREEK PHI SYMBOL
+
 Pi:
   amslatex: "$\\pi$"
   esc-alias: p
@@ -5863,11 +6551,13 @@ Pi:
   unicode-equivalent-name: GREEK SMALL LETTER PI
   wl-unicode: "\u03C0"
   wl-unicode-name: GREEK SMALL LETTER PI
+
 Piecewise:
   esc-alias: pw
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF361"
+
 PiscesSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5875,6 +6565,7 @@ PiscesSign:
   unicode-equivalent-name: PISCES
   wl-unicode: "\u2653"
   wl-unicode-name: PISCES
+
 Placeholder:
   esc-alias: pl
   has-unicode-inverse: true
@@ -5882,16 +6573,17 @@ Placeholder:
   unicode-equivalent: "\u2395"
   unicode-equivalent-name: APL FUNCTIONAL SYMBOL QUAD
   wl-unicode: "\uF528"
+
 Plus:
   ascii: "+"
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Plus
   precedence: 310
-  unicode-equivalent: "+"
   unicode-equivalent-name: PLUS SIGN
   wl-unicode: "+"
   wl-unicode-name: PLUS SIGN
+
 PlusMinus:
   amslatex: "\\pm"
   esc-alias: +-
@@ -5901,6 +6593,7 @@ PlusMinus:
   unicode-equivalent-name: PLUS-MINUS SIGN
   wl-unicode: "\xB1"
   wl-unicode-name: PLUS-MINUS SIGN
+
 Pluto:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5908,22 +6601,24 @@ Pluto:
   unicode-equivalent-name: PLUTO
   wl-unicode: "\u2647"
   wl-unicode-name: PLUTO
+
 Postfix:
   ascii: "//"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Postfix
   precedence: 70
+
 Power:
   ascii: "^"
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Power
   precedence: 590
-  unicode-equivalent: "^"
   unicode-equivalent-name: CIRCUMFLEX ACCENT
   wl-unicode: "^"
   wl-unicode-name: CIRCUMFLEX ACCENT
+
 Precedes:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5932,6 +6627,7 @@ Precedes:
   unicode-equivalent-name: PRECEDES
   wl-unicode: "\u227A"
   wl-unicode-name: PRECEDES
+
 PrecedesEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5940,6 +6636,7 @@ PrecedesEqual:
   unicode-equivalent-name: PRECEDES ABOVE SINGLE-LINE EQUALS SIGN
   wl-unicode: "\u2AAF"
   wl-unicode-name: PRECEDES ABOVE SINGLE-LINE EQUALS SIGN
+
 PrecedesSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5948,6 +6645,7 @@ PrecedesSlantEqual:
   unicode-equivalent-name: PRECEDES OR EQUAL TO
   wl-unicode: "\u227C"
   wl-unicode-name: PRECEDES OR EQUAL TO
+
 PrecedesTilde:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5972,6 +6670,7 @@ Prime:
   unicode-equivalent-name: PRIME
   wl-unicode: "\u2032"
   wl-unicode-name: PRIME
+
 Product:
   amslatex: "\\prod"
   esc-alias: prod
@@ -5982,6 +6681,7 @@ Product:
   unicode-equivalent-name: N-ARY PRODUCT
   wl-unicode: "\u220F"
   wl-unicode-name: N-ARY PRODUCT
+
 Proportion:
   has-unicode-inverse: false
   is-letter-like: false
@@ -5990,6 +6690,7 @@ Proportion:
   unicode-equivalent-name: PROPORTION
   wl-unicode: "\u2237"
   wl-unicode-name: PROPORTION
+
 Proportional:
   amslatex: "\\propto"
   esc-alias: prop
@@ -6000,6 +6701,7 @@ Proportional:
   unicode-equivalent-name: PROPORTIONAL TO
   wl-unicode: "\u221D"
   wl-unicode-name: PROPORTIONAL TO
+
 Psi:
   amslatex: "\\psi"
   esc-alias: ps
@@ -6009,18 +6711,21 @@ Psi:
   unicode-equivalent-name: GREEK SMALL LETTER PSI
   wl-unicode: "\u03C8"
   wl-unicode-name: GREEK SMALL LETTER PSI
+
 Put:
   ascii: ">>"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Put
   precedence: 30
+
 PutAppend:
   ascii: ">>>"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: PutAppend
   precedence: 30
+
 QuarterNote:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6028,6 +6733,7 @@ QuarterNote:
   unicode-equivalent-name: QUARTER NOTE
   wl-unicode: "\u2669"
   wl-unicode-name: QUARTER NOTE
+
 RHacek:
   amslatex: "\\v{r}"
   esc-alias: rv
@@ -6037,18 +6743,17 @@ RHacek:
   unicode-equivalent-name: LATIN SMALL LETTER R WITH CARON
   wl-unicode: "\u0159"
   wl-unicode-name: LATIN SMALL LETTER R WITH CARON
+
 # See also Function
 RawAmpersand:
   ascii: '&'
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: "&"
 
 RawAt:
   ascii: '@'
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: "@"
 
 RawBackquote:
   has-unicode-inverse: false
@@ -6057,6 +6762,7 @@ RawBackquote:
   unicode-equivalent-name: GRAVE ACCENT
   wl-unicode: '`'
   wl-unicode-name: GRAVE ACCENT
+
 RawBackslash:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6069,20 +6775,17 @@ RawColon:
   ascii: ':'
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: ":"
 
 RawComma:
   ascii: ','
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: ","
 
 RawDollar:
   ascii: '$'
   has-unicode-inverse: false
   is-letter-like: true
   # Since we have an is-letter-like, we add wl-unicode for the checker to work.
-  unicode-equivalent: "$"
   wl-unicode: "$"
   wl-unicode-name: DOLLAR SIGN
 
@@ -6090,7 +6793,6 @@ RawDoubleQuote:
   ascii: '"'
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '"'
 
 RawEscape:
   has-unicode-inverse: false
@@ -6103,7 +6805,6 @@ RawGreater:
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: RawGreater
-  unicode-equivalent: "\u003e"
   unicode-equivalent-name: GREATER-THAN SIGN
   wl-unicode: "\u003e"
   wl-unicode-name: GREATER-THAN SIGN
@@ -6112,51 +6813,47 @@ RawLeftBrace:
   ascii: '{'
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '{'
 
 RawLeftBracket:
   ascii: '['
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '['
 
 RawLeftParenthesis:
   ascii: '('
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '('
 
 RawNumberSign:
   ascii: "#"
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '#'
 
 RawPercent:
   ascii: "%"
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '%'
 
 # See also Definition and PatternTest
 RawQuestion:
   ascii: "?"
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '?'
 
 RawQuote:
+  ascii: "'"
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: "'"
   unicode-equivalent-name: APOSTROPHE
   wl-unicode: "'"
   wl-unicode-name: APOSTROPHE
+
 RawReturn:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u000D"
   wl-unicode: "\u000D"
+
 RawRightBrace:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6164,6 +6861,7 @@ RawRightBrace:
   unicode-equivalent-name: RIGHT CURLY BRACKET
   wl-unicode: '}'
   wl-unicode-name: RIGHT CURLY BRACKET
+
 RawRightBracket:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6171,6 +6869,7 @@ RawRightBracket:
   unicode-equivalent-name: RIGHT SQUARE BRACKET
   wl-unicode: ']'
   wl-unicode-name: RIGHT SQUARE BRACKET
+
 RawRightParenthesis:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6178,6 +6877,7 @@ RawRightParenthesis:
   unicode-equivalent-name: RIGHT PARENTHESIS
   wl-unicode: )
   wl-unicode-name: RIGHT PARENTHESIS
+
 RawSemicolon:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6195,6 +6895,7 @@ RawSlash:
   unicode-equivalent-name: SOLIDUS
   wl-unicode: /
   wl-unicode-name: SOLIDUS
+
 RawSpace:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6202,6 +6903,7 @@ RawSpace:
   unicode-equivalent-name: SPACE
   wl-unicode: ' '
   wl-unicode-name: SPACE
+
 RawStar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6209,6 +6911,7 @@ RawStar:
   unicode-equivalent-name: ASTERISK
   wl-unicode: '*'
   wl-unicode-name: ASTERISK
+
 RawTab:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6219,14 +6922,13 @@ RawTilde:
   ascii: '~'
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '~'
   wl-unicode: '~'
   wl-unicode-name: TILDE
 
 RawUnderscore:
+  ascii: "_"
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: _
   unicode-equivalent-name: LOW LINE
   wl-unicode: _
   wl-unicode-name: LOW LINE
@@ -6236,10 +6938,10 @@ RawVerticalBar:
   ascii: "|"
   has-unicode-inverse: false
   is-letter-like: false
-  unicode-equivalent: '|'
   unicode-equivalent-name: VERTICAL LINE
   wl-unicode: '|'
   wl-unicode-name: VERTICAL LINE
+
 RegisteredTrademark:
   esc-alias: rtm
   has-unicode-inverse: false
@@ -6269,12 +6971,14 @@ ReplaceAll:
   is-letter-like: false
   operator-name: ReplaceAll
   precedence: 110
+
 ReplaceRepeated:
   ascii: "//."
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: ReplaceRepeated
   precedence: 110
+
 ReturnIndicator:
   esc-alias: ret
   has-unicode-inverse: false
@@ -6283,11 +6987,13 @@ ReturnIndicator:
   unicode-equivalent-name: DOWNWARDS ARROW WITH CORNER LEFTWARDS
   wl-unicode: "\u21B5"
   wl-unicode-name: DOWNWARDS ARROW WITH CORNER LEFTWARDS
+
 ReturnKey:
   esc-alias: ' ret'
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF766"
+
 ReverseDoublePrime:
   esc-alias: '``'
   has-unicode-inverse: false
@@ -6296,6 +7002,7 @@ ReverseDoublePrime:
   unicode-equivalent-name: REVERSED DOUBLE PRIME
   wl-unicode: "\u2036"
   wl-unicode-name: REVERSED DOUBLE PRIME
+
 ReverseElement:
   amslatex: "\\ni"
   esc-alias: mem
@@ -6306,6 +7013,7 @@ ReverseElement:
   unicode-equivalent-name: CONTAINS AS MEMBER
   wl-unicode: "\u220B"
   wl-unicode-name: CONTAINS AS MEMBER
+
 ReverseEquilibrium:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6314,6 +7022,7 @@ ReverseEquilibrium:
   unicode-equivalent-name: LEFTWARDS HARPOON OVER RIGHTWARDS HARPOON
   wl-unicode: "\u21CB"
   wl-unicode-name: LEFTWARDS HARPOON OVER RIGHTWARDS HARPOON
+
 ReversePrime:
   esc-alias: '`'
   has-unicode-inverse: false
@@ -6322,6 +7031,7 @@ ReversePrime:
   unicode-equivalent-name: REVERSED PRIME
   wl-unicode: "\u2035"
   wl-unicode-name: REVERSED PRIME
+
 ReverseUpEquilibrium:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6332,6 +7042,7 @@ ReverseUpEquilibrium:
   wl-unicode: "\u296F"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB LEFT BESIDE UPWARDS HARPOON WITH BARB
     RIGHT
+
 Rho:
   amslatex: "\\rho"
   esc-alias: r
@@ -6341,6 +7052,7 @@ Rho:
   unicode-equivalent-name: GREEK SMALL LETTER RHO
   wl-unicode: "\u03C1"
   wl-unicode-name: GREEK SMALL LETTER RHO
+
 RightAngle:
   amslatex: "\\rightangle"
   has-unicode-inverse: false
@@ -6349,6 +7061,7 @@ RightAngle:
   unicode-equivalent-name: RIGHT ANGLE
   wl-unicode: "\u221F"
   wl-unicode-name: RIGHT ANGLE
+
 RightAngleBracket:
   esc-alias: '>'
   has-unicode-inverse: false
@@ -6357,6 +7070,7 @@ RightAngleBracket:
   unicode-equivalent-name: RIGHT-POINTING ANGLE BRACKET
   wl-unicode: "\u232A"
   wl-unicode-name: RIGHT-POINTING ANGLE BRACKET
+
 RightArrow:
   amslatex: "\\rightarrow"
   esc-alias: ' ->'
@@ -6367,6 +7081,7 @@ RightArrow:
   unicode-equivalent-name: RIGHTWARDS ARROW
   wl-unicode: "\u2192"
   wl-unicode-name: RIGHTWARDS ARROW
+
 RightArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6375,6 +7090,7 @@ RightArrowBar:
   unicode-equivalent-name: RIGHTWARDS ARROW TO BAR
   wl-unicode: "\u21E5"
   wl-unicode-name: RIGHTWARDS ARROW TO BAR
+
 RightArrowLeftArrow:
   amslatex: "\\rightleftarrows"
   has-unicode-inverse: false
@@ -6384,11 +7100,13 @@ RightArrowLeftArrow:
   unicode-equivalent-name: RIGHTWARDS ARROW OVER LEFTWARDS ARROW
   wl-unicode: "\u21C4"
   wl-unicode-name: RIGHTWARDS ARROW OVER LEFTWARDS ARROW
+
 RightAssociation:
   esc-alias: '|>'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF114"
+
 RightBracketingBar:
   esc-alias: r|
   has-unicode-inverse: false
@@ -6396,6 +7114,7 @@ RightBracketingBar:
   unicode-equivalent: '|'
   unicode-equivalent-name: VERTICAL LINE
   wl-unicode: "\uF604"
+
 RightCeiling:
   esc-alias: rc
   has-unicode-inverse: false
@@ -6405,11 +7124,13 @@ RightCeiling:
   unicode-equivalent-name: RIGHT CEILING
   wl-unicode: "\u2309"
   wl-unicode-name: RIGHT CEILING
+
 RightComposition:
   ascii: "/*"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightComposition
+
 RightDoubleBracket:
   esc-alias: ']]'
   has-unicode-inverse: false
@@ -6418,6 +7139,7 @@ RightDoubleBracket:
   unicode-equivalent-name: RIGHT WHITE SQUARE BRACKET
   wl-unicode: "\u301B"
   wl-unicode-name: RIGHT WHITE SQUARE BRACKET
+
 RightDoubleBracketingBar:
   ascii: "||"
   has-unicode-inverse: false
@@ -6427,6 +7149,7 @@ RightDoubleBracketingBar:
   unicode-equivalent: "\u2016"
   unicode-equivalent-name: DOUBLE VERTICAL LINE
   wl-unicode: "\uF606"
+
 RightDownTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6435,6 +7158,7 @@ RightDownTeeVector:
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB RIGHT FROM BAR
   wl-unicode: "\u295D"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB RIGHT FROM BAR
+
 RightDownVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6443,6 +7167,7 @@ RightDownVector:
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB RIGHTWARDS
   wl-unicode: "\u21C2"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB RIGHTWARDS
+
 RightDownVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6451,6 +7176,7 @@ RightDownVectorBar:
   unicode-equivalent-name: DOWNWARDS HARPOON WITH BARB RIGHT TO BAR
   wl-unicode: "\u2955"
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB RIGHT TO BAR
+
 RightFloor:
   esc-alias: rf
   has-unicode-inverse: false
@@ -6460,6 +7186,7 @@ RightFloor:
   unicode-equivalent-name: RIGHT FLOOR
   wl-unicode: "\u230B"
   wl-unicode-name: RIGHT FLOOR
+
 RightGuillemet:
   esc-alias: g>>
   has-unicode-inverse: false
@@ -6468,11 +7195,13 @@ RightGuillemet:
   unicode-equivalent-name: RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
   wl-unicode: "\xBB"
   wl-unicode-name: RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+
 RightModified:
   esc-alias: ']'
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF76C"
+
 RightPointer:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6481,12 +7210,14 @@ RightPointer:
   unicode-equivalent-name: BLACK RIGHT-POINTING SMALL TRIANGLE
   wl-unicode: "\u25B8"
   wl-unicode-name: BLACK RIGHT-POINTING SMALL TRIANGLE
+
 RightSkeleton:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\xBB"
   unicode-equivalent-name: RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
   wl-unicode: "\uF762"
+
 RightTee:
   esc-alias: rT
   has-unicode-inverse: false
@@ -6496,6 +7227,7 @@ RightTee:
   unicode-equivalent-name: RIGHT TACK
   wl-unicode: "\u22A2"
   wl-unicode-name: RIGHT TACK
+
 RightTeeArrow:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6503,6 +7235,7 @@ RightTeeArrow:
   unicode-equivalent-name: RIGHTWARDS ARROW FROM BAR
   wl-unicode: "\u21A6"
   wl-unicode-name: RIGHTWARDS ARROW FROM BAR
+
 RightTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6511,6 +7244,7 @@ RightTeeVector:
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB UP FROM BAR
   wl-unicode: "\u295B"
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB UP FROM BAR
+
 RightTriangle:
   amslatex: "\\triangleright"
   has-unicode-inverse: false
@@ -6520,6 +7254,7 @@ RightTriangle:
   unicode-equivalent-name: CONTAINS AS NORMAL SUBGROUP
   wl-unicode: "\u22B3"
   wl-unicode-name: CONTAINS AS NORMAL SUBGROUP
+
 RightTriangleBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6528,6 +7263,7 @@ RightTriangleBar:
   unicode-equivalent-name: VERTICAL BAR BESIDE RIGHT TRIANGLE
   wl-unicode: "\u29D0"
   wl-unicode-name: VERTICAL BAR BESIDE RIGHT TRIANGLE
+
 RightTriangleEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6536,6 +7272,7 @@ RightTriangleEqual:
   unicode-equivalent-name: CONTAINS AS NORMAL SUBGROUP OR EQUAL TO
   wl-unicode: "\u22B5"
   wl-unicode-name: CONTAINS AS NORMAL SUBGROUP OR EQUAL TO
+
 RightUpDownVector:
   has-unicode-inverse: false
   operator-name: RightUpDownVector
@@ -6544,6 +7281,7 @@ RightUpDownVector:
   unicode-equivalent-name: UP BARB RIGHT DOWN BARB RIGHT HARPOON
   wl-unicode: "\u294F"
   wl-unicode-name: UP BARB RIGHT DOWN BARB RIGHT HARPOON
+
 RightUpTeeVector:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6552,6 +7290,7 @@ RightUpTeeVector:
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB RIGHT FROM BAR
   wl-unicode: "\u295C"
   wl-unicode-name: UPWARDS HARPOON WITH BARB RIGHT FROM BAR
+
 RightUpVector:
   amslatex: "\\upharpoonright"
   has-unicode-inverse: false
@@ -6561,6 +7300,7 @@ RightUpVector:
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB RIGHTWARDS
   wl-unicode: "\u21BE"
   wl-unicode-name: UPWARDS HARPOON WITH BARB RIGHTWARDS
+
 RightUpVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6569,6 +7309,7 @@ RightUpVectorBar:
   unicode-equivalent-name: UPWARDS HARPOON WITH BARB RIGHT TO BAR
   wl-unicode: "\u2954"
   wl-unicode-name: UPWARDS HARPOON WITH BARB RIGHT TO BAR
+
 RightVector:
   esc-alias: vec
   has-unicode-inverse: false
@@ -6578,6 +7319,7 @@ RightVector:
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB UPWARDS
   wl-unicode: "\u21C0"
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB UPWARDS
+
 RightVectorBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6586,6 +7328,7 @@ RightVectorBar:
   unicode-equivalent-name: RIGHTWARDS HARPOON WITH BARB UP TO BAR
   wl-unicode: "\u2953"
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB UP TO BAR
+
 RoundImplies:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6594,10 +7337,12 @@ RoundImplies:
   unicode-equivalent-name: RIGHT DOUBLE ARROW WITH ROUNDED HEAD
   wl-unicode: "\u2970"
   wl-unicode-name: RIGHT DOUBLE ARROW WITH ROUNDED HEAD
+
 RoundSpaceIndicator:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3B2"
+
 Rule:
   ascii: "->"
   esc-alias: "->"
@@ -6608,6 +7353,7 @@ Rule:
   unicode-equivalent: "\u2192"
   unicode-equivalent-name: RIGHTWARDS ARROW
   wl-unicode: "\uF522"
+
 RuleDelayed:
   ascii: ":>"
   esc-alias: ":>"
@@ -6618,6 +7364,7 @@ RuleDelayed:
   unicode-equivalent: "\u29F4"
   unicode-equivalent-name: RULE-DELAYED
   wl-unicode: "\uF51F"
+
 SHacek:
   amslatex: "\v{s}"
   esc-alias: sv
@@ -6627,6 +7374,7 @@ SHacek:
   unicode-equivalent-name: LATIN SMALL LETTER S WITH CARON
   wl-unicode: "\u0161"
   wl-unicode-name: LATIN SMALL LETTER S WITH CARON
+
 SZ:
   esc-alias: sz
   has-unicode-inverse: false
@@ -6635,6 +7383,7 @@ SZ:
   unicode-equivalent-name: LATIN SMALL LETTER SHARP S
   wl-unicode: "\xDF"
   wl-unicode-name: LATIN SMALL LETTER SHARP S
+
 SadSmiley:
   esc-alias: :-(
   has-unicode-inverse: false
@@ -6643,6 +7392,7 @@ SadSmiley:
   unicode-equivalent-name: WHITE FROWNING FACE
   wl-unicode: "\u2639"
   wl-unicode-name: WHITE FROWNING FACE
+
 SagittariusSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6650,12 +7400,14 @@ SagittariusSign:
   unicode-equivalent-name: SAGITTARIUS
   wl-unicode: "\u2650"
   wl-unicode-name: SAGITTARIUS
+
 SameQ:
   ascii: "==="
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SameQ
   precedence: 290
+
 Sampi:
   esc-alias: sa
   has-unicode-inverse: true
@@ -6664,6 +7416,7 @@ Sampi:
   unicode-equivalent-name: GREEK SMALL LETTER SAMPI
   wl-unicode: "\u03E1"
   wl-unicode-name: GREEK SMALL LETTER SAMPI
+
 Saturn:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6671,6 +7424,7 @@ Saturn:
   unicode-equivalent-name: SATURN
   wl-unicode: "\u2644"
   wl-unicode-name: SATURN
+
 ScorpioSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -6678,6 +7432,7 @@ ScorpioSign:
   unicode-equivalent-name: SCORPIUS
   wl-unicode: "\u264F"
   wl-unicode-name: SCORPIUS
+
 ScriptA:
   esc-alias: sca
   has-unicode-inverse: true
@@ -6685,6 +7440,7 @@ ScriptA:
   unicode-equivalent: "\U0001D4B6"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL A
   wl-unicode: "\uF6B2"
+
 ScriptB:
   esc-alias: scb
   has-unicode-inverse: true
@@ -6692,6 +7448,7 @@ ScriptB:
   unicode-equivalent: "\U0001D4B7"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL B
   wl-unicode: "\uF6B3"
+
 ScriptC:
   esc-alias: scc
   has-unicode-inverse: true
@@ -6699,6 +7456,7 @@ ScriptC:
   unicode-equivalent: "\U0001D4B8"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL C
   wl-unicode: "\uF6B4"
+
 ScriptCapitalA:
   esc-alias: scA
   has-unicode-inverse: true
@@ -6706,6 +7464,7 @@ ScriptCapitalA:
   unicode-equivalent: "\U0001D49C"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL A
   wl-unicode: "\uF770"
+
 ScriptCapitalB:
   amslatex: "\\mathcal{B}"
   esc-alias: scB
@@ -6715,6 +7474,7 @@ ScriptCapitalB:
   unicode-equivalent-name: SCRIPT CAPITAL B
   wl-unicode: "\u212C"
   wl-unicode-name: SCRIPT CAPITAL B
+
 ScriptCapitalC:
   esc-alias: scC
   has-unicode-inverse: true
@@ -6722,6 +7482,7 @@ ScriptCapitalC:
   unicode-equivalent: "\U0001D49E"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL C
   wl-unicode: "\uF772"
+
 ScriptCapitalD:
   esc-alias: scD
   has-unicode-inverse: true
@@ -6729,6 +7490,7 @@ ScriptCapitalD:
   unicode-equivalent: "\U0001D49F"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL D
   wl-unicode: "\uF773"
+
 ScriptCapitalE:
   amslatex: "\\mathcal{E}"
   esc-alias: scE
@@ -6738,6 +7500,7 @@ ScriptCapitalE:
   unicode-equivalent-name: SCRIPT CAPITAL E
   wl-unicode: "\u2130"
   wl-unicode-name: SCRIPT CAPITAL E
+
 ScriptCapitalF:
   amslatex: "\\mathcal{F}"
   esc-alias: scF
@@ -6747,6 +7510,7 @@ ScriptCapitalF:
   unicode-equivalent-name: SCRIPT CAPITAL F
   wl-unicode: "\u2131"
   wl-unicode-name: SCRIPT CAPITAL F
+
 ScriptCapitalG:
   esc-alias: scG
   has-unicode-inverse: true
@@ -6754,6 +7518,7 @@ ScriptCapitalG:
   unicode-equivalent: "\U0001D4A2"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL G
   wl-unicode: "\uF776"
+
 ScriptCapitalH:
   esc-alias: scH
   has-unicode-inverse: false
@@ -6762,6 +7527,7 @@ ScriptCapitalH:
   unicode-equivalent-name: SCRIPT CAPITAL H
   wl-unicode: "\u210B"
   wl-unicode-name: SCRIPT CAPITAL H
+
 ScriptCapitalI:
   esc-alias: scI
   has-unicode-inverse: false
@@ -6770,6 +7536,7 @@ ScriptCapitalI:
   unicode-equivalent-name: SCRIPT CAPITAL I
   wl-unicode: "\u2110"
   wl-unicode-name: SCRIPT CAPITAL I
+
 ScriptCapitalJ:
   esc-alias: scJ
   has-unicode-inverse: true
@@ -6777,6 +7544,7 @@ ScriptCapitalJ:
   unicode-equivalent: "\U0001D4A5"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL J
   wl-unicode: "\uF779"
+
 ScriptCapitalK:
   esc-alias: scK
   has-unicode-inverse: true
@@ -6784,6 +7552,7 @@ ScriptCapitalK:
   unicode-equivalent: "\U0001D4A6"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL K
   wl-unicode: "\uF77A"
+
 ScriptCapitalL:
   esc-alias: scL
   has-unicode-inverse: false
@@ -6792,6 +7561,7 @@ ScriptCapitalL:
   unicode-equivalent-name: SCRIPT CAPITAL L
   wl-unicode: "\u2112"
   wl-unicode-name: SCRIPT CAPITAL L
+
 ScriptCapitalM:
   amslatex: "\\mathcal{M}"
   esc-alias: scM
@@ -6801,6 +7571,7 @@ ScriptCapitalM:
   unicode-equivalent-name: SCRIPT CAPITAL M
   wl-unicode: "\u2133"
   wl-unicode-name: SCRIPT CAPITAL M
+
 ScriptCapitalN:
   esc-alias: scN
   has-unicode-inverse: false
@@ -6808,6 +7579,7 @@ ScriptCapitalN:
   unicode-equivalent: "\U0001D4A9"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL N
   wl-unicode: "\uF77D"
+
 ScriptCapitalO:
   esc-alias: scO
   has-unicode-inverse: true
@@ -6815,6 +7587,7 @@ ScriptCapitalO:
   unicode-equivalent: "\U0001D4AA"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL O
   wl-unicode: "\uF77E"
+
 ScriptCapitalP:
   esc-alias: scP
   has-unicode-inverse: false
@@ -6822,6 +7595,7 @@ ScriptCapitalP:
   unicode-equivalent: "\U0001D4AB"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL P
   wl-unicode: "\uF77F"
+
 ScriptCapitalQ:
   esc-alias: scQ
   has-unicode-inverse: true
@@ -6829,6 +7603,7 @@ ScriptCapitalQ:
   unicode-equivalent: "\U0001D4AC"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL Q
   wl-unicode: "\uF780"
+
 ScriptCapitalR:
   esc-alias: scR
   has-unicode-inverse: false
@@ -6837,6 +7612,7 @@ ScriptCapitalR:
   unicode-equivalent-name: SCRIPT CAPITAL R
   wl-unicode: "\u211B"
   wl-unicode-name: SCRIPT CAPITAL R
+
 ScriptCapitalS:
   esc-alias: scS
   has-unicode-inverse: true
@@ -6844,6 +7620,7 @@ ScriptCapitalS:
   unicode-equivalent: "\U0001D4AE"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL S
   wl-unicode: "\uF782"
+
 ScriptCapitalT:
   esc-alias: scT
   has-unicode-inverse: true
@@ -6851,6 +7628,7 @@ ScriptCapitalT:
   unicode-equivalent: "\U0001D4AF"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL T
   wl-unicode: "\uF783"
+
 ScriptCapitalU:
   esc-alias: scU
   has-unicode-inverse: true
@@ -6858,6 +7636,7 @@ ScriptCapitalU:
   unicode-equivalent: "\U0001D4B0"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL U
   wl-unicode: "\uF784"
+
 ScriptCapitalV:
   esc-alias: scV
   has-unicode-inverse: true
@@ -6865,6 +7644,7 @@ ScriptCapitalV:
   unicode-equivalent: "\U0001D4B1"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL V
   wl-unicode: "\uF785"
+
 ScriptCapitalW:
   esc-alias: scW
   has-unicode-inverse: true
@@ -6872,6 +7652,7 @@ ScriptCapitalW:
   unicode-equivalent: "\U0001D4B2"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL W
   wl-unicode: "\uF786"
+
 ScriptCapitalX:
   esc-alias: scX
   has-unicode-inverse: true
@@ -6879,6 +7660,7 @@ ScriptCapitalX:
   unicode-equivalent: "\U0001D4B3"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL X
   wl-unicode: "\uF787"
+
 ScriptCapitalY:
   esc-alias: scY
   has-unicode-inverse: true
@@ -6886,6 +7668,7 @@ ScriptCapitalY:
   unicode-equivalent: "\U0001D4B4"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL Y
   wl-unicode: "\uF788"
+
 ScriptCapitalZ:
   esc-alias: scZ
   has-unicode-inverse: true
@@ -6893,6 +7676,7 @@ ScriptCapitalZ:
   unicode-equivalent: "\U0001D4B5"
   unicode-equivalent-name: MATHEMATICAL SCRIPT CAPITAL Z
   wl-unicode: "\uF789"
+
 ScriptD:
   esc-alias: scd
   has-unicode-inverse: true
@@ -6900,18 +7684,21 @@ ScriptD:
   unicode-equivalent: "\U0001D4B9"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL D
   wl-unicode: "\uF6B5"
+
 ScriptDotlessI:
   has-unicode-inverse: false
   is-letter-like: true
   unicode-equivalent: "\U0001D4BE"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL I
   wl-unicode: "\uF730"
+
 ScriptDotlessJ:
   has-unicode-inverse: false
   is-letter-like: true
   unicode-equivalent: "\U0001D4BF"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL J
   wl-unicode: "\uF731"
+
 ScriptE:
   amslatex: "\\mathcal{e}"
   esc-alias: sce
@@ -6921,11 +7708,13 @@ ScriptE:
   unicode-equivalent-name: SCRIPT SMALL E
   wl-unicode: "\u212F"
   wl-unicode-name: SCRIPT SMALL E
+
 ScriptEight:
   esc-alias: sc8
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F8"
+
 ScriptF:
   esc-alias: scf
   has-unicode-inverse: true
@@ -6933,16 +7722,19 @@ ScriptF:
   unicode-equivalent: "\U0001D4BB"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL F
   wl-unicode: "\uF6B7"
+
 ScriptFive:
   esc-alias: sc5
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F5"
+
 ScriptFour:
   esc-alias: sc4
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F4"
+
 ScriptG:
   esc-alias: scg
   has-unicode-inverse: false
@@ -6951,6 +7743,7 @@ ScriptG:
   unicode-equivalent-name: SCRIPT SMALL G
   wl-unicode: "\u210A"
   wl-unicode-name: SCRIPT SMALL G
+
 ScriptH:
   esc-alias: sch
   has-unicode-inverse: true
@@ -6958,6 +7751,7 @@ ScriptH:
   unicode-equivalent: "\U0001D4BD"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL H
   wl-unicode: "\uF6B9"
+
 ScriptI:
   esc-alias: sci
   has-unicode-inverse: true
@@ -6965,6 +7759,7 @@ ScriptI:
   unicode-equivalent: "\U0001D4BE"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL I
   wl-unicode: "\uF6BA"
+
 ScriptJ:
   esc-alias: scj
   has-unicode-inverse: true
@@ -6972,6 +7767,7 @@ ScriptJ:
   unicode-equivalent: "\U0001D4BF"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL J
   wl-unicode: "\uF6BB"
+
 ScriptK:
   esc-alias: sck
   has-unicode-inverse: true
@@ -6979,6 +7775,7 @@ ScriptK:
   unicode-equivalent: "\U0001D4C0"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL K
   wl-unicode: "\uF6BC"
+
 ScriptL:
   esc-alias: scl
   has-unicode-inverse: false
@@ -6987,6 +7784,7 @@ ScriptL:
   unicode-equivalent-name: SCRIPT SMALL L
   wl-unicode: "\u2113"
   wl-unicode-name: SCRIPT SMALL L
+
 ScriptM:
   esc-alias: scm
   has-unicode-inverse: true
@@ -6994,6 +7792,7 @@ ScriptM:
   unicode-equivalent: "\U0001D4C2"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL M
   wl-unicode: "\uF6BE"
+
 ScriptN:
   esc-alias: scn
   has-unicode-inverse: true
@@ -7001,11 +7800,13 @@ ScriptN:
   unicode-equivalent: "\U0001D4C3"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL N
   wl-unicode: "\uF6BF"
+
 ScriptNine:
   esc-alias: sc9
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F9"
+
 ScriptO:
   amslatex: "\\mathcal{o}"
   esc-alias: sco
@@ -7015,11 +7816,13 @@ ScriptO:
   unicode-equivalent-name: SCRIPT SMALL O
   wl-unicode: "\u2134"
   wl-unicode-name: SCRIPT SMALL O
+
 ScriptOne:
   esc-alias: sc1
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F1"
+
 ScriptP:
   esc-alias: scp
   has-unicode-inverse: true
@@ -7027,6 +7830,7 @@ ScriptP:
   unicode-equivalent: "\U0001D4C5"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL P
   wl-unicode: "\uF6C1"
+
 ScriptQ:
   esc-alias: scq
   has-unicode-inverse: true
@@ -7034,6 +7838,7 @@ ScriptQ:
   unicode-equivalent: "\U0001D4C6"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL Q
   wl-unicode: "\uF6C2"
+
 ScriptR:
   esc-alias: scr
   has-unicode-inverse: true
@@ -7041,6 +7846,7 @@ ScriptR:
   unicode-equivalent: "\U0001D4C7"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL R
   wl-unicode: "\uF6C3"
+
 ScriptS:
   esc-alias: scs
   has-unicode-inverse: true
@@ -7048,16 +7854,19 @@ ScriptS:
   unicode-equivalent: "\U0001D4C8"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL S
   wl-unicode: "\uF6C4"
+
 ScriptSeven:
   esc-alias: sc7
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F7"
+
 ScriptSix:
   esc-alias: sc6
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F6"
+
 ScriptT:
   esc-alias: sct
   has-unicode-inverse: true
@@ -7065,16 +7874,19 @@ ScriptT:
   unicode-equivalent: "\U0001D4C9"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL T
   wl-unicode: "\uF6C5"
+
 ScriptThree:
   esc-alias: sc3
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F3"
+
 ScriptTwo:
   esc-alias: sc2
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F2"
+
 ScriptU:
   esc-alias: scu
   has-unicode-inverse: true
@@ -7082,6 +7894,7 @@ ScriptU:
   unicode-equivalent: "\U0001D4CA"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL U
   wl-unicode: "\uF6C6"
+
 ScriptV:
   esc-alias: scv
   has-unicode-inverse: true
@@ -7089,6 +7902,7 @@ ScriptV:
   unicode-equivalent: "\U0001D4CB"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL V
   wl-unicode: "\uF6C7"
+
 ScriptW:
   esc-alias: scw
   has-unicode-inverse: true
@@ -7096,6 +7910,7 @@ ScriptW:
   unicode-equivalent: "\U0001D4CC"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL W
   wl-unicode: "\uF6C8"
+
 ScriptX:
   esc-alias: scx
   has-unicode-inverse: true
@@ -7103,6 +7918,7 @@ ScriptX:
   unicode-equivalent: "\U0001D4CD"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL X
   wl-unicode: "\uF6C9"
+
 ScriptY:
   esc-alias: scy
   has-unicode-inverse: true
@@ -7110,6 +7926,7 @@ ScriptY:
   unicode-equivalent: "\U0001D4CE"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL Y
   wl-unicode: "\uF6CA"
+
 ScriptZ:
   esc-alias: scz
   has-unicode-inverse: true
@@ -7117,11 +7934,13 @@ ScriptZ:
   unicode-equivalent: "\U0001D4CF"
   unicode-equivalent-name: MATHEMATICAL SCRIPT SMALL Z
   wl-unicode: "\uF6CB"
+
 ScriptZero:
   esc-alias: sc0
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7F0"
+
 Section:
   has-unicode-inverse: false
   is-letter-like: true
@@ -7129,26 +7948,29 @@ Section:
   unicode-equivalent-name: SECTION SIGN
   wl-unicode: "\xA7"
   wl-unicode-name: SECTION SIGN
+
 SelectionPlaceholder:
   esc-alias: spl
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF527"
+
 Set:
   ascii: "="
   has-unicode-inverse: true
   is-letter-like: false
   operator-name: Set
   precedence: 40
-  unicode-equivalent: "="
   unicode-equivalent-name: EQUALS SIGN
   wl-unicode: "="
   wl-unicode-name: EQUALS SIGN
+
 SetDelayed:
   ascii: ":="
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SetDelayed
+
 Sharp:
   has-unicode-inverse: false
   is-letter-like: true
@@ -7156,24 +7978,28 @@ Sharp:
   unicode-equivalent-name: MUSIC SHARP SIGN
   wl-unicode: "\u266F"
   wl-unicode-name: MUSIC SHARP SIGN
+
 ShortDownArrow:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2193"
   unicode-equivalent-name: DOWNWARDS ARROW
   wl-unicode: "\uF52B"
+
 ShortLeftArrow:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2190"
   unicode-equivalent-name: LEFTWARDS ARROW
   wl-unicode: "\uF526"
+
 ShortRightArrow:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2192"
   unicode-equivalent-name: RIGHTWARDS ARROW
   wl-unicode: "\uF525"
+
 ShortUpArrow:
   amslatex: "\\uparrow"
   has-unicode-inverse: true
@@ -7181,6 +8007,7 @@ ShortUpArrow:
   unicode-equivalent: "\u2191"
   unicode-equivalent-name: UPWARDS ARROW
   wl-unicode: "\uF52A"
+
 Sigma:
   amslatex: "\\sigma"
   esc-alias: s
@@ -7190,6 +8017,7 @@ Sigma:
   unicode-equivalent-name: GREEK SMALL LETTER SIGMA
   wl-unicode: "\u03C3"
   wl-unicode-name: GREEK SMALL LETTER SIGMA
+
 SixPointedStar:
   esc-alias: '*6'
   has-unicode-inverse: false
@@ -7198,6 +8026,7 @@ SixPointedStar:
   unicode-equivalent-name: SIX POINTED BLACK STAR
   wl-unicode: "\u2736"
   wl-unicode-name: SIX POINTED BLACK STAR
+
 SkeletonIndicator:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7205,6 +8034,7 @@ SkeletonIndicator:
   unicode-equivalent-name: HYPHEN BULLET
   wl-unicode: "\u2043"
   wl-unicode-name: HYPHEN BULLET
+
 SmallCircle:
   esc-alias: sc
   has-unicode-inverse: false
@@ -7213,6 +8043,7 @@ SmallCircle:
   unicode-equivalent-name: RING OPERATOR
   wl-unicode: "\u2218"
   wl-unicode-name: RING OPERATOR
+
 SpaceIndicator:
   esc-alias: space
   has-unicode-inverse: false
@@ -7221,11 +8052,13 @@ SpaceIndicator:
   unicode-equivalent-name: OPEN BOX
   wl-unicode: "\u2423"
   wl-unicode-name: OPEN BOX
+
 SpaceKey:
   esc-alias: spc
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7BF"
+
 SpadeSuit:
   has-unicode-inverse: false
   is-letter-like: true
@@ -7233,12 +8066,14 @@ SpadeSuit:
   unicode-equivalent-name: BLACK SPADE SUIT
   wl-unicode: "\u2660"
   wl-unicode-name: BLACK SPADE SUIT
+
 Span:
   ascii: ";;"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Span
   precedence: 305
+
 SpanFromAbove:
   esc-alias: sfa
   has-unicode-inverse: false
@@ -7246,6 +8081,7 @@ SpanFromAbove:
   unicode-equivalent: "\u22EE"
   unicode-equivalent-name: VERTICAL ELLIPSIS
   wl-unicode: "\uF3BB"
+
 SpanFromBoth:
   esc-alias: sfb
   has-unicode-inverse: false
@@ -7253,6 +8089,7 @@ SpanFromBoth:
   unicode-equivalent: "\u22F1"
   unicode-equivalent-name: DOWN RIGHT DIAGONAL ELLIPSIS
   wl-unicode: "\uF3BC"
+
 SpanFromLeft:
   esc-alias: sfl
   has-unicode-inverse: false
@@ -7260,6 +8097,7 @@ SpanFromLeft:
   unicode-equivalent: "\u22EF"
   unicode-equivalent-name: MIDLINE HORIZONTAL ELLIPSIS
   wl-unicode: "\uF3BA"
+
 SphericalAngle:
   amslatex: "\\sphericalangle"
   has-unicode-inverse: false
@@ -7268,6 +8106,7 @@ SphericalAngle:
   unicode-equivalent-name: SPHERICAL ANGLE
   wl-unicode: "\u2222"
   wl-unicode-name: SPHERICAL ANGLE
+
 Sqrt:
   amslatex: "\\sqrt"
   esc-alias: sqrt
@@ -7278,6 +8117,7 @@ Sqrt:
   unicode-equivalent-name: SQUARE ROOT
   wl-unicode: "\u221A"
   wl-unicode-name: SQUARE ROOT
+
 Square:
   esc-alias: sq
   has-unicode-inverse: true
@@ -7285,6 +8125,7 @@ Square:
   unicode-equivalent: "\u25AB"
   unicode-equivalent-name: WHITE SMALL SQUARE
   wl-unicode: "\uF520"
+
 SquareIntersection:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7293,6 +8134,7 @@ SquareIntersection:
   unicode-equivalent-name: SQUARE CAP
   wl-unicode: "\u2293"
   wl-unicode-name: SQUARE CAP
+
 SquareSubset:
   amslatex: "\\sqsubset"
   has-unicode-inverse: false
@@ -7302,6 +8144,7 @@ SquareSubset:
   unicode-equivalent-name: SQUARE IMAGE OF
   wl-unicode: "\u228F"
   wl-unicode-name: SQUARE IMAGE OF
+
 SquareSubsetEqual:
   amslatex: "\\sqsubseteq"
   has-unicode-inverse: false
@@ -7311,6 +8154,7 @@ SquareSubsetEqual:
   unicode-equivalent-name: SQUARE IMAGE OF OR EQUAL TO
   wl-unicode: "\u2291"
   wl-unicode-name: SQUARE IMAGE OF OR EQUAL TO
+
 SquareSuperset:
   amslatex: "\\sqsupset"
   has-unicode-inverse: false
@@ -7320,6 +8164,7 @@ SquareSuperset:
   unicode-equivalent-name: SQUARE ORIGINAL OF
   wl-unicode: "\u2290"
   wl-unicode-name: SQUARE ORIGINAL OF
+
 SquareSupersetEqual:
   amslatex: "\\sqsupseteq"
   has-unicode-inverse: false
@@ -7329,6 +8174,7 @@ SquareSupersetEqual:
   unicode-equivalent-name: SQUARE ORIGINAL OF OR EQUAL TO
   wl-unicode: "\u2292"
   wl-unicode-name: SQUARE ORIGINAL OF OR EQUAL TO
+
 SquareUnion:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7337,6 +8183,7 @@ SquareUnion:
   unicode-equivalent-name: SQUARE CUP
   wl-unicode: "\u2294"
   wl-unicode-name: SQUARE CUP
+
 Star:
   amslatex: "\\star"
   esc-alias: star
@@ -7346,6 +8193,7 @@ Star:
   unicode-equivalent-name: STAR OPERATOR
   wl-unicode: "\u22C6"
   wl-unicode-name: STAR OPERATOR
+
 Sterling:
   has-unicode-inverse: false
   is-letter-like: true
@@ -7353,6 +8201,7 @@ Sterling:
   unicode-equivalent-name: POUND SIGN
   wl-unicode: "\xA3"
   wl-unicode-name: POUND SIGN
+
 Stigma:
   esc-alias: sti
   has-unicode-inverse: false
@@ -7386,6 +8235,7 @@ Subset:
   unicode-equivalent-name: SUBSET OF
   wl-unicode: "\u2282"
   wl-unicode-name: SUBSET OF
+
 SubsetEqual:
   amslatex: "\\subseteq"
   esc-alias: sub=
@@ -7396,11 +8246,13 @@ SubsetEqual:
   unicode-equivalent-name: SUBSET OF OR EQUAL TO
   wl-unicode: "\u2286"
   wl-unicode-name: SUBSET OF OR EQUAL TO
+
 SubtractFrom:
   ascii: "-="
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SubtractFrom
+
 Succeeds:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7409,6 +8261,7 @@ Succeeds:
   operator-name: Succeeds
   wl-unicode: "\u227B"
   wl-unicode-name: SUCCEEDS
+
 SucceedsEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7417,6 +8270,7 @@ SucceedsEqual:
   unicode-equivalent-name: SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN
   wl-unicode: "\u2AB0"
   wl-unicode-name: SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN
+
 SucceedsSlantEqual:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7425,6 +8279,7 @@ SucceedsSlantEqual:
   unicode-equivalent-name: SUCCEEDS OR EQUAL TO
   wl-unicode: "\u227D"
   wl-unicode-name: SUCCEEDS OR EQUAL TO
+
 SucceedsTilde:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7433,6 +8288,7 @@ SucceedsTilde:
   unicode-equivalent-name: SUCCEEDS OR EQUIVALENT TO
   wl-unicode: "\u227F"
   wl-unicode-name: SUCCEEDS OR EQUIVALENT TO
+
 SuchThat:
   esc-alias: st
   has-unicode-inverse: false
@@ -7442,6 +8298,7 @@ SuchThat:
   unicode-equivalent-name: SMALL CONTAINS AS MEMBER
   wl-unicode: "\u220D"
   wl-unicode-name: SMALL CONTAINS AS MEMBER
+
 Sum:
   amslatex: "\\sum"
   esc-alias: sum
@@ -7452,6 +8309,7 @@ Sum:
   unicode-equivalent-name: N-ARY SUMMATION
   wl-unicode: "\u2211"
   wl-unicode-name: N-ARY SUMMATION
+
 Superset:
   esc-alias: sup
   has-unicode-inverse: false
@@ -7461,6 +8319,7 @@ Superset:
   unicode-equivalent-name: SUPERSET OF
   wl-unicode: "\u2283"
   wl-unicode-name: SUPERSET OF
+
 SupersetEqual:
   esc-alias: sup=
   has-unicode-inverse: false
@@ -7470,14 +8329,17 @@ SupersetEqual:
   unicode-equivalent-name: SUPERSET OF OR EQUAL TO
   wl-unicode: "\u2287"
   wl-unicode-name: SUPERSET OF OR EQUAL TO
+
 SystemEnterKey:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF75F"
+
 SystemsModelDelay:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3AF"
+
 THacek:
   amslatex: "\\v{t}"
   esc-alias: tv
@@ -7487,16 +8349,19 @@ THacek:
   unicode-equivalent-name: LATIN SMALL LETTER T WITH CARON
   wl-unicode: "\u0165"
   wl-unicode-name: LATIN SMALL LETTER T WITH CARON
+
 TabKey:
   esc-alias: tab
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF7BE"
+
 TagSet:
   ascii: "/:"
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: TagSet
+
 Tau:
   amslatex: "\\tau"
   esc-alias: t
@@ -7506,6 +8371,7 @@ Tau:
   unicode-equivalent-name: GREEK SMALL LETTER TAU
   wl-unicode: "\u03C4"
   wl-unicode-name: GREEK SMALL LETTER TAU
+
 TaurusSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7513,16 +8379,19 @@ TaurusSign:
   unicode-equivalent-name: TAURUS
   wl-unicode: "\u2649"
   wl-unicode-name: TAURUS
+
 TensorProduct:
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2297"
   unicode-equivalent-name: CIRCLED TIMES
   wl-unicode: "\uF3DA"
+
 TensorWedge:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF3DB"
+
 Therefore:
   esc-alias: tf
   has-unicode-inverse: false
@@ -7532,6 +8401,7 @@ Therefore:
   unicode-equivalent-name: THEREFORE
   wl-unicode: "\u2234"
   wl-unicode-name: THEREFORE
+
 Theta:
   amslatex: "\\theta"
   esc-alias: th
@@ -7541,6 +8411,7 @@ Theta:
   unicode-equivalent-name: GREEK SMALL LETTER THETA
   wl-unicode: "\u03B8"
   wl-unicode-name: GREEK SMALL LETTER THETA
+
 ThickSpace:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7548,11 +8419,13 @@ ThickSpace:
   unicode-equivalent-name: FOUR-PER-EM SPACE
   wl-unicode: "\u2005"
   wl-unicode-name: FOUR-PER-EM SPACE
+
 ThinSpace:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\u2009"
   wl-unicode-name: THIN SPACE
+
 Thorn:
   esc-alias: thn
   has-unicode-inverse: false
@@ -7587,6 +8460,7 @@ TildeEqual:
   unicode-equivalent-name: ASYMPTOTICALLY EQUAL TO
   wl-unicode: "\u2243"
   wl-unicode-name: ASYMPTOTICALLY EQUAL TO
+
 TildeFullEqual:
   esc-alias: ~==
   has-unicode-inverse: false
@@ -7596,6 +8470,7 @@ TildeFullEqual:
   unicode-equivalent-name: APPROXIMATELY EQUAL TO
   wl-unicode: "\u2245"
   wl-unicode-name: APPROXIMATELY EQUAL TO
+
 TildeTilde:
   esc-alias: ~~
   has-unicode-inverse: false
@@ -7605,6 +8480,7 @@ TildeTilde:
   unicode-equivalent-name: ALMOST EQUAL TO
   wl-unicode: "\u2248"
   wl-unicode-name: ALMOST EQUAL TO
+
 Times:
   amslatex: "\\times"
   ascii: '*'
@@ -7617,11 +8493,13 @@ Times:
   unicode-equivalent-name: MULTIPLICATION SIGN
   wl-unicode: "\xD7"
   wl-unicode-name: MULTIPLICATION SIGN
+
 TimesBy:
   ascii: "*="
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: TimesBy
+
 Trademark:
   esc-alias: tm
   has-unicode-inverse: false
@@ -7630,6 +8508,7 @@ Trademark:
   unicode-equivalent-name: TRADE MARK SIGN
   wl-unicode: "\u2122"
   wl-unicode-name: TRADE MARK SIGN
+
 Transpose:
   esc-alias: tr
   has-unicode-inverse: true
@@ -7638,12 +8517,14 @@ Transpose:
   unicode-equivalent: "\u1D40"
   unicode-equivalent-name: MODIFIER LETTER CAPITAL T
   wl-unicode: "\uF3C7"
+
 TripleDot:
   has-unicode-inverse: false
   is-letter-like: false
   unicode-equivalent: "\u22EF"
   unicode-equivalent-name: MIDLINE HORIZONTAL ELLIPSIS
   wl-unicode: "\uF758"
+
 UAcute:
   amslatex: "\\'{u}"
   esc-alias: u'
@@ -7653,6 +8534,7 @@ UAcute:
   unicode-equivalent-name: LATIN SMALL LETTER U WITH ACUTE
   wl-unicode: "\xFA"
   wl-unicode-name: LATIN SMALL LETTER U WITH ACUTE
+
 UDoubleAcute:
   esc-alias: u''
   has-unicode-inverse: false
@@ -7661,6 +8543,7 @@ UDoubleAcute:
   unicode-equivalent-name: LATIN SMALL LETTER U WITH DOUBLE ACUTE
   wl-unicode: "\u0171"
   wl-unicode-name: LATIN SMALL LETTER U WITH DOUBLE ACUTE
+
 UDoubleDot:
   esc-alias: u"
   has-unicode-inverse: false
@@ -7669,6 +8552,7 @@ UDoubleDot:
   unicode-equivalent-name: LATIN SMALL LETTER U WITH DIAERESIS
   wl-unicode: "\xFC"
   wl-unicode-name: LATIN SMALL LETTER U WITH DIAERESIS
+
 UGrave:
   amslatex: "\\`{u}"
   esc-alias: u`
@@ -7678,6 +8562,7 @@ UGrave:
   unicode-equivalent-name: LATIN SMALL LETTER U WITH GRAVE
   wl-unicode: "\xF9"
   wl-unicode-name: LATIN SMALL LETTER U WITH GRAVE
+
 UHat:
   esc-alias: u^
   has-unicode-inverse: false
@@ -7686,6 +8571,7 @@ UHat:
   unicode-equivalent-name: LATIN SMALL LETTER U WITH CIRCUMFLEX
   wl-unicode: "\xFB"
   wl-unicode-name: LATIN SMALL LETTER U WITH CIRCUMFLEX
+
 URing:
   esc-alias: uo
   has-unicode-inverse: false
@@ -7694,6 +8580,7 @@ URing:
   unicode-equivalent-name: LATIN SMALL LETTER U WITH RING ABOVE
   wl-unicode: "\u016F"
   wl-unicode-name: LATIN SMALL LETTER U WITH RING ABOVE
+
 UnderBrace:
   esc-alias: u{
   has-unicode-inverse: false
@@ -7702,6 +8589,7 @@ UnderBrace:
   unicode-equivalent-name: PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
   wl-unicode: "\uFE38"
   wl-unicode-name: PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
+
 UnderBracket:
   esc-alias: u[
   has-unicode-inverse: false
@@ -7710,6 +8598,7 @@ UnderBracket:
   unicode-equivalent-name: BOTTOM SQUARE BRACKET
   wl-unicode: "\u23B5"
   wl-unicode-name: BOTTOM SQUARE BRACKET
+
 UnderParenthesis:
   esc-alias: u(
   has-unicode-inverse: false
@@ -7718,6 +8607,7 @@ UnderParenthesis:
   unicode-equivalent-name: PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
   wl-unicode: "\uFE36"
   wl-unicode-name: PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
+
 UndirectedEdge:
   ascii: "<->"
   esc-alias: ue
@@ -7727,11 +8617,13 @@ UndirectedEdge:
   unicode-equivalent: "\u2194"
   unicode-equivalent-name: LEFT RIGHT ARROW
   wl-unicode: "\uF3D4"
+
 UnSameQ:
   ascii: "=!="
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UnSameQ
+
 Union:
   esc-alias: un
   has-unicode-inverse: false
@@ -7741,6 +8633,7 @@ Union:
   unicode-equivalent-name: N-ARY UNION
   wl-unicode: "\u22C3"
   wl-unicode-name: N-ARY UNION
+
 UnionPlus:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7749,12 +8642,14 @@ UnionPlus:
   unicode-equivalent-name: MULTISET UNION
   wl-unicode: "\u228E"
   wl-unicode-name: MULTISET UNION
+
 Unset:
   ascii: "=."
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Unset
   precedence: 670
+
 UpArrow:
   amslatex: "\\uparrow"
   has-unicode-inverse: false
@@ -7764,6 +8659,7 @@ UpArrow:
   unicode-equivalent-name: UPWARDS ARROW
   wl-unicode: "\u2191"
   wl-unicode-name: UPWARDS ARROW
+
 UpArrowBar:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7772,6 +8668,7 @@ UpArrowBar:
   unicode-equivalent-name: UPWARDS ARROW TO BAR
   wl-unicode: "\u2912"
   wl-unicode-name: UPWARDS ARROW TO BAR
+
 UpArrowDownArrow:
   amslatex: "\\updownarrows"
   has-unicode-inverse: false
@@ -7781,6 +8678,7 @@ UpArrowDownArrow:
   unicode-equivalent-name: UPWARDS ARROW LEFTWARDS OF DOWNWARDS ARROW
   wl-unicode: "\u21C5"
   wl-unicode-name: UPWARDS ARROW LEFTWARDS OF DOWNWARDS ARROW
+
 UpDownArrow:
   amslatex: "\\updownarrow"
   has-unicode-inverse: false
@@ -7790,6 +8688,7 @@ UpDownArrow:
   unicode-equivalent-name: UP DOWN ARROW
   wl-unicode: "\u2195"
   wl-unicode-name: UP DOWN ARROW
+
 UpEquilibrium:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7800,6 +8699,7 @@ UpEquilibrium:
   wl-unicode: "\u296E"
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON WITH BARB
     RIGHT
+
 UpPointer:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7807,6 +8707,7 @@ UpPointer:
   unicode-equivalent-name: BLACK UP-POINTING SMALL TRIANGLE
   wl-unicode: "\u25B4"
   wl-unicode-name: BLACK UP-POINTING SMALL TRIANGLE
+
 UpTee:
   esc-alias: uT
   has-unicode-inverse: false
@@ -7816,6 +8717,7 @@ UpTee:
   unicode-equivalent-name: UP TACK
   wl-unicode: "\u22A5"
   wl-unicode-name: UP TACK
+
 UpTeeArrow:
   amslatex: "\\MapsUp"
   has-unicode-inverse: false
@@ -7825,6 +8727,7 @@ UpTeeArrow:
   unicode-equivalent-name: UPWARDS ARROW FROM BAR
   wl-unicode: "\u21A5"
   wl-unicode-name: UPWARDS ARROW FROM BAR
+
 UpperLeftArrow:
   amslatex: "\\nwarrow"
   has-unicode-inverse: false
@@ -7834,6 +8737,7 @@ UpperLeftArrow:
   unicode-equivalent-name: NORTH WEST ARROW
   wl-unicode: "\u2196"
   wl-unicode-name: NORTH WEST ARROW
+
 UpperRightArrow:
   amslatex: "\\nearrow"
   has-unicode-inverse: false
@@ -7843,6 +8747,7 @@ UpperRightArrow:
   unicode-equivalent-name: NORTH EAST ARROW
   wl-unicode: "\u2197"
   wl-unicode-name: NORTH EAST ARROW
+
 Upsilon:
   amslatex: "\\upsilon"
   esc-alias: u
@@ -7852,12 +8757,14 @@ Upsilon:
   unicode-equivalent-name: GREEK SMALL LETTER UPSILON
   wl-unicode: "\u03C5"
   wl-unicode-name: GREEK SMALL LETTER UPSILON
+
 UpSet:
   ascii: "^="
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UpSet
   precedence: 40
+
 UpSetDelayed:
   ascii: "^:="
   has-unicode-inverse: false
@@ -7876,6 +8783,7 @@ Uranus:
   unicode-equivalent-name: URANUS
   wl-unicode: "\u2645"
   wl-unicode-name: URANUS
+
 Vee:
   amslatex: "\\vee"
   esc-alias: v
@@ -7886,6 +8794,7 @@ Vee:
   unicode-equivalent-name: N-ARY LOGICAL OR
   wl-unicode: "\u22C1"
   wl-unicode-name: N-ARY LOGICAL OR
+
 Venus:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7893,6 +8802,7 @@ Venus:
   unicode-equivalent-name: FEMALE SIGN
   wl-unicode: "\u2640"
   wl-unicode-name: FEMALE SIGN
+
 VerticalBar:
   esc-alias: ' |'
   has-unicode-inverse: true
@@ -7901,6 +8811,7 @@ VerticalBar:
   unicode-equivalent-name: VERTICAL BAR
   wl-unicode: "\uF3D0"
   wl-unicode-name: LIGHT VERTICAL BAR
+
 VerticalEllipsis:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7908,6 +8819,7 @@ VerticalEllipsis:
   unicode-equivalent-name: VERTICAL ELLIPSIS
   wl-unicode: "\u22EE"
   wl-unicode-name: VERTICAL ELLIPSIS
+
 VerticalLine:
   esc-alias: vline
   has-unicode-inverse: false
@@ -7916,11 +8828,13 @@ VerticalLine:
   unicode-equivalent-name: BOX DRAWINGS LIGHT VERTICAL
   wl-unicode: "\u2502"
   wl-unicode-name: BOX DRAWINGS LIGHT VERTICAL
+
 VerticalSeparator:
   esc-alias: '|'
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF432"
+
 VerticalTilde:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7929,6 +8843,7 @@ VerticalTilde:
   unicode-equivalent-name: WREATH PRODUCT
   wl-unicode: "\u2240"
   wl-unicode-name: WREATH PRODUCT
+
 VeryThinSpace:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7936,6 +8851,7 @@ VeryThinSpace:
   unicode-equivalent-name: HAIR SPACE
   wl-unicode: "\u200A"
   wl-unicode-name: HAIR SPACE
+
 VirgoSign:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7943,10 +8859,12 @@ VirgoSign:
   unicode-equivalent-name: VIRGO
   wl-unicode: "\u264D"
   wl-unicode-name: VIRGO
+
 WarningSign:
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF725"
+
 WatchIcon:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7954,6 +8872,7 @@ WatchIcon:
   unicode-equivalent-name: WATCH
   wl-unicode: "\u231A"
   wl-unicode-name: WATCH
+
 Wedge:
   amslatex: "\\wedge"
   esc-alias: ^
@@ -7976,6 +8895,7 @@ WeierstrassP:
   unicode-equivalent-name: SCRIPT CAPITAL P
   wl-unicode: "\u2118"
   wl-unicode-name: SCRIPT CAPITAL P
+
 WhiteBishop:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7983,6 +8903,7 @@ WhiteBishop:
   unicode-equivalent-name: WHITE CHESS BISHOP
   wl-unicode: "\u2657"
   wl-unicode-name: WHITE CHESS BISHOP
+
 WhiteKing:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7990,6 +8911,7 @@ WhiteKing:
   unicode-equivalent-name: WHITE CHESS KING
   wl-unicode: "\u2654"
   wl-unicode-name: WHITE CHESS KING
+
 WhiteKnight:
   has-unicode-inverse: false
   is-letter-like: false
@@ -7997,6 +8919,7 @@ WhiteKnight:
   unicode-equivalent-name: WHITE CHESS KNIGHT
   wl-unicode: "\u2658"
   wl-unicode-name: WHITE CHESS KNIGHT
+
 WhitePawn:
   has-unicode-inverse: false
   is-letter-like: false
@@ -8004,6 +8927,7 @@ WhitePawn:
   unicode-equivalent-name: WHITE CHESS PAWN
   wl-unicode: "\u2659"
   wl-unicode-name: WHITE CHESS PAWN
+
 WhiteQueen:
   has-unicode-inverse: false
   is-letter-like: false
@@ -8011,6 +8935,7 @@ WhiteQueen:
   unicode-equivalent-name: WHITE CHESS QUEEN
   wl-unicode: "\u2655"
   wl-unicode-name: WHITE CHESS QUEEN
+
 WhiteRook:
   has-unicode-inverse: false
   is-letter-like: false
@@ -8018,19 +8943,23 @@ WhiteRook:
   unicode-equivalent-name: WHITE CHESS ROOK
   wl-unicode: "\u2656"
   wl-unicode-name: WHITE CHESS ROOK
+
 Wolf:
   esc-alias: wf
   has-unicode-inverse: false
   is-letter-like: true
   wl-unicode: "\uF720"
+
 WolframLanguageLogo:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF11E"
+
 WolframLanguageLogoCircle:
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF11F"
+
 Xi:
   amslatex: "\\xi"
   esc-alias: x
@@ -8040,11 +8969,13 @@ Xi:
   unicode-equivalent-name: GREEK SMALL LETTER XI
   wl-unicode: "\u03BE"
   wl-unicode-name: GREEK SMALL LETTER XI
+
 Xnor:
   esc-alias: xnor
   has-unicode-inverse: false
   is-letter-like: false
   wl-unicode: "\uF4A2"
+
 Xor:
   amslatex: "$\\oplus$" # The WL veebar-looking symbol isn't in AMSLaTeX
   esc-alias: xor
@@ -8056,6 +8987,7 @@ Xor:
   unicode-equivalent-name: XOR
   wl-unicode: "\u22BB"
   wl-unicode-name: XOR
+
 YAcute:
   amslatex: "\\'{y}"
   esc-alias: y'
@@ -8065,6 +8997,7 @@ YAcute:
   unicode-equivalent-name: LATIN SMALL LETTER Y WITH ACUTE
   wl-unicode: "\xFD"
   wl-unicode-name: LATIN SMALL LETTER Y WITH ACUTE
+
 YDoubleDot:
   esc-alias: y"
   has-unicode-inverse: false
@@ -8073,6 +9006,7 @@ YDoubleDot:
   unicode-equivalent-name: LATIN SMALL LETTER Y WITH DIAERESIS
   wl-unicode: "\xFF"
   wl-unicode-name: LATIN SMALL LETTER Y WITH DIAERESIS
+
 Yen:
   has-unicode-inverse: false
   is-letter-like: true
@@ -8080,6 +9014,7 @@ Yen:
   unicode-equivalent-name: YEN SIGN
   wl-unicode: "\xA5"
   wl-unicode-name: YEN SIGN
+
 ZHacek:
   amslatex: "\v{z}"
   esc-alias: zv
@@ -8089,6 +9024,7 @@ ZHacek:
   unicode-equivalent-name: LATIN SMALL LETTER Z WITH CARON
   wl-unicode: "\u017E"
   wl-unicode-name: LATIN SMALL LETTER Z WITH CARON
+
 Zeta:
   amslatex: "\\zeta"
   esc-alias: z

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -49,7 +49,7 @@ def get_plain_text(char_name: str, char_data: dict, use_unicode: bool) -> str:
 
     Failing above, return \\[char_name]]
     """
-    uni = char_data.get("unicode-equivalent")
+    uni = char_data.get("unicode-equivalent", char_data.get("ascii"))
 
     if uni is not None:
         if use_unicode:
@@ -118,12 +118,12 @@ def compile_tables(data: dict) -> dict:
         if "operator-name" in v and "unicode-equivalent" in v
     }
 
-    # Conversion from unicode to wl dictionary entry.
+    # Conversion from unicode or ascii to wl dictionary entry.
     # We filter the dictionary after it's first created to redundant entries
     unicode_to_wl_dict = {
-        v["unicode-equivalent"]: v["wl-unicode"]
+        v.get("unicode-equivalent", v.get("ascii")): v["wl-unicode"]
         for v in data.values()
-        if "unicode-equivalent" in v and v["has-unicode-inverse"]
+        if ("unicode-equivalent" in v or "ascii" in v) and v["has-unicode-inverse"]
     }
     unicode_to_wl_dict = {k: v for k, v in unicode_to_wl_dict.items() if k != v}
     unicode_to_wl_re = re_from_keys(unicode_to_wl_dict)

--- a/mathics_scanner/generate/build_tables.py
+++ b/mathics_scanner/generate/build_tables.py
@@ -97,6 +97,13 @@ def compile_tables(data: dict) -> dict:
         if "esc-alias" in v
     }
 
+    # WL to AMS LaTeX characters
+    wl_to_amslatex = {
+        v["wl-unicode"]: v.get("amslatex")
+        for v in data.values()
+        if "amslatex" in v and "wl-unicode" in v
+    }
+
     # operator-to-unicode dictionary entry
     operator_to_precedence = {
         v["operator-name"]: v["precedence"]
@@ -188,6 +195,7 @@ def compile_tables(data: dict) -> dict:
         "unicode-to-wl-re": unicode_to_wl_re,
         "wl-to-ascii-dict": wl_to_ascii_dict,
         "wl-to-ascii-re": wl_to_ascii_re,
+        "wl-to-amslatex": wl_to_amslatex,
         "wl-to-unicode-dict": wl_to_unicode_dict,
         "wl-to-unicode-re": wl_to_unicode_re,
     }
@@ -207,6 +215,7 @@ ALL_FIELDS = [
     "unicode-to-operator",
     "unicode-to-wl-dict",
     "unicode-to-wl-re",
+    "wl-to-amslatex",
     "wl-to-ascii-dict",
     "wl-to-ascii-re",
     "wl-to-unicode-dict",

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -148,7 +148,7 @@ tokens = [
     ("ConjugateTranspose", r" \uf3c9 "),
     ("HermitianConjugate", r" \uf3ce "),
     ("Integral", r" \u222b "),
-    ("DifferentialD", r" \U0001D451 "),
+    ("DifferentialD", r" \u1d451 | \uf74c"),
     ("Del", r" \u2207 "),
     # uf520 is Wolfram custom, 25ab is standard unicode
     ("Square", r" \uf520 | \u25ab"),

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -148,7 +148,7 @@ tokens = [
     ("ConjugateTranspose", r" \uf3c9 "),
     ("HermitianConjugate", r" \uf3ce "),
     ("Integral", r" \u222b "),
-    ("DifferentialD", r" \u1d451 | \uf74c"),
+    ("DifferentialD", r" \U0001D451 | \uf74c"),
     ("Del", r" \u2207 "),
     # uf520 is Wolfram custom, 25ab is standard unicode
     ("Square", r" \uf520 | \u25ab"),

--- a/test/test_ascii.py
+++ b/test/test_ascii.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from mathics_scanner.load import (
+    load_mathics_character_yaml,
+    load_mathics_character_json,
+)
+
+yaml_data = load_mathics_character_yaml()
+json_data = load_mathics_character_json()
+
+
+def test_ascii():
+    ascii_operator_to_name = json_data["ascii-operator-to-name"]
+    ascii_operators = json_data["ascii-operators"]
+    operator_keys = frozenset(ascii_operator_to_name.keys())
+    # operator_to_precedence = json_data["operator-to-precedence"]
+    for chars in json_data["ascii-operators"]:
+        assert chars in ascii_operators
+        assert chars in operator_keys
+        # assert chars in unicode_to_operator.keys()
+        name = ascii_operator_to_name.get(chars)
+        assert name is not None
+        assert name.startswith(r"\[")
+        assert name.endswith(r"]")
+        raw_name = name[len(r"\[") : -len(r"]")]
+        assert raw_name in yaml_data

--- a/test/test_general_yaml_sanity.py
+++ b/test/test_general_yaml_sanity.py
@@ -155,8 +155,8 @@ def test_unicode_name():
             ), f"{k} has unicode-equivalent-name set to {real_name} but it should be {expected_name}"
         else:
             assert (
-                "unicode-equivalent-name" not in v
-            ), f"{k} has unicode-equivalent-name set to {v['unicode-equivalent-name']} but it doesn't have a unicode equivalent"
+                "ascii" in v
+            ), f"{k} has unicode-equivalent-name set to {v['unicode-equivalent-name']} but it doesn't have a unicode or ascii equivalent"
 
 
 def test_wl_unicode():
@@ -168,8 +168,8 @@ def test_wl_unicode():
                 # unique equivalent
                 continue
         assert (
-            "wl-unicode" in v or "unicode-equivalent" in v
-        ), f"{k} has neither wl-unicode nor unicode-equivalent attribute"
+            "wl-unicode" in v or "unicode-equivalent" in v or "ascii" in v
+        ), f"{k} has neither wl-unicode, unicode-equivalent, nor ascii attribute"
 
 
 def test_unicode_operators():

--- a/test/test_has_unicode_inverse_sanity.py
+++ b/test/test_has_unicode_inverse_sanity.py
@@ -15,10 +15,10 @@ def test_has_unicode_inverse_sanity():
     for k, v in yaml_data.items():
         if v["has-unicode-inverse"]:
             assert (
-                "unicode-equivalent" in v
-            ), f"key {k} has a unicode inverse but has no unicode equivalent"
+                "unicode-equivalent" in v or "ascii" in v
+            ), f"key {k} has a unicode inverse but has no unicode equivalent or ascii"
 
-            uni = v["unicode-equivalent"]
+            uni = v.get("unicode-equivalent", v.get("ascii"))
 
             assert uni not in inverses, f"unicode character {uni} has multiple inverses"
 

--- a/test/test_table_consistency.py
+++ b/test/test_table_consistency.py
@@ -19,9 +19,9 @@ def test_roundtrip():
     for k, v in yaml_data.items():
         if v["has-unicode-inverse"]:
             assert (
-                "unicode-equivalent" in v
+                "unicode-equivalent" in v or "ascii" in v
             ), f"{k} has unicode-inverse but no unicode equivalent"
-            uni = v["unicode-equivalent"]
+            uni = v.get("unicode-equivalent", v.get("ascii"))
             wl = v["wl-unicode"]
             assert (
                 unicode_to_wl(wl_to_unicode(wl)) == wl

--- a/test/test_tokeniser.py
+++ b/test/test_tokeniser.py
@@ -125,10 +125,10 @@ def test_int_repeated():
 
 
 def test_integeral():
-    assert tokens("\u222B x \U0001D451 y") == [
+    assert tokens("\u222B x \uf74c y") == [
         Token("Integral", "\u222B", 0),
         Token("Symbol", "x", 2),
-        Token("DifferentialD", "\U0001D451", 4),
+        Token("DifferentialD", "\uf74c", 4),
         Token("Symbol", "y", 6),
     ]
 

--- a/test/test_translation_regressions.py
+++ b/test/test_translation_regressions.py
@@ -11,7 +11,7 @@ def check_translation_regression(c: str, expected_translation: str):
 
 
 def test_translation_regressions():
-    check_translation_regression("DifferentialD", "𝑑")
+    check_translation_regression("DifferentialD", "\U0001D451")
     check_translation_regression("PartialD", "\u2202")
     check_translation_regression("Uranus", "\u2645")
     check_translation_regression("WeierstrassP", "\u2118")

--- a/test/test_unicode_equivalent.py
+++ b/test/test_unicode_equivalent.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from mathics_scanner.load import (
+    load_mathics_character_yaml,
+    load_mathics_character_json,
+)
+
+yaml_data = load_mathics_character_yaml()
+json_data = load_mathics_character_json()
+
+
+def test_has_unicode_equivalent():
+    for k, v in yaml_data.items():
+        unicode_equivalent = v.get("unicode-equivalent", None)
+        if unicode_equivalent is not None:
+            assert unicode_equivalent != v.get(
+                "ascii"
+            ), f"In {k} - remove add unicode equivalent"


### PR DESCRIPTION
Go over character tables
    
* Separate entries with a blank line
*  Remove "unicode-equivalent" when it is the same as "ascii"
    
Because of this, `wl_to_unicode()` needs to use "ascii" when there is no unicode-equivalent, but  "has-unicode-inverse" is set.
    
* Add test that unicode-equivalent isn't the same things as ascii
* Include ASCII operators in tables
* Correct DifferentialD unicode - it was correct in master .   Note: \U0001D451 != \u1d451
* Add conversion table `ascii-operator-to-name` to convert an ASCII operator to its WMA name