### PR TITLE
Administrivia:

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
     - id: trailing-whitespace
     - id: check-json
       exclude: mathics_scanner/data/characters.json
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        stages: [commit]
 -   repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -1687,7 +1687,7 @@ Definition:
 # is valid, and this would not be the case if this symbol were
 # not letterlike.
 
-# On some keyboards 186 can sometimes appear as the keyboad symbol,
+# On some keyboards 186 can sometimes appear as the keyboard symbol,
 # but according to
 # https://reference.wolfram.com/language/ref/character/Degree.html the
 # right value is 176 which is the same as the Unicode value. These

--- a/mathics_scanner/errors.py
+++ b/mathics_scanner/errors.py
@@ -2,7 +2,10 @@
 
 
 class TranslateError(Exception):
-    """A generic class of tokenization errors. This exception is subclassed by other tokenization errors"""
+    """
+    A generic class of tokenization errors. This exception is subclassed by other
+    tokenization errors
+    """
 
     pass
 

--- a/mathics_scanner/feed.py
+++ b/mathics_scanner/feed.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-Rather than trying to parse all the lines of code at once, this module implements methods
-for returning one line code at a time.
+Rather than trying to parse all the lines of code at once, this module implements
+methods for returning one line code at a time.
 """
 
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 
 
 class LineFeeder(metaclass=ABCMeta):

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -62,7 +62,7 @@ tokens = [
     #
     ("LeftRowBox", r" \\\( "),
     ("RightRowBox", r" \\\) "),
-    # Box operators which are valid only inside Box delimiters
+    # Box Operators which are valid only inside Box delimiters
     ("InterpretedBox", r" \\\! "),
     ("SuperscriptBox", r" \\\^ "),
     ("SubscriptBox", r" \\\_ "),
@@ -74,7 +74,7 @@ tokens = [
     ("RadicalBox", r" \\\@ "),
     ("FormBox", r" \\\` "),
     #
-    # end bloxes
+    # End Box Operators
     #
     ("Information", r"\?\?"),
     ("PatternTest", r" \? "),

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -3,6 +3,7 @@
 
 import re
 import string
+from typing import Optional
 
 from mathics_scanner.characters import _letterlikes, _letters
 from mathics_scanner.errors import ScanError
@@ -280,7 +281,7 @@ for c in string.digits:
     literal_tokens[c] = ["Number"]
 
 
-def find_indices(literals) -> dict:
+def find_indices(literals: dict) -> dict:
     "find indices of literal tokens"
 
     literal_indices = {}
@@ -314,7 +315,7 @@ filename_tokens = compile_tokens(filename_tokens)
 full_symbol_pattern = compile_pattern(full_symbol_pattern)
 
 
-def is_symbol_name(text):
+def is_symbol_name(text: str) -> bool:
     """
     Returns ``True`` if ``text`` is a valid identifier. Otherwise returns
     ``False``.
@@ -324,11 +325,11 @@ def is_symbol_name(text):
 
 
 class Token(object):
-    "A representation of a Wolfram Language token."
+    "A representation of a token for parsing the Wolfram Language."
 
-    def __init__(self, tag, text, pos):
+    def __init__(self, tag: str, text: str, pos: int):
         """
-        :param tag: A string that indicates which type of token this is.
+        :param tag: which type of token this is.
         :param text: The actual contents of the token.
         :param pos: The position of the token in the input feed.
         """
@@ -344,30 +345,33 @@ class Token(object):
         )
 
     def __repr__(self):
-        return "Token(%s, %s, %i)" % (self.tag, self.text, self.pos)
+        return f"Token({self.tag}, {self.text}, {self.pos})"
 
 
-class Tokeniser(object):
+class Tokeniser:
     """
-    A tokeniser for the Wolfram Language.
+    This converts input strings from a feeder and
+    produces tokens of the Wolfram Language which can then be used in parsing.
     """
 
     modes = {"expr": (tokens, token_indices), "filename": (filename_tokens, {})}
 
     def __init__(self, feeder):
         """
-        :param feeder: An instance of ``LineFeeder`` which will feed characters
-                       to the tokeniser.
+        feeder: An instance of ``LineFeeder`` from which we receive
+                input srings that are to be split up and put into tokens.
         """
         self.pos = 0
         self.feeder = feeder
         self.prescanner = Prescanner(feeder)
         self.code = self.prescanner.replace_escape_sequences()
-        self._change_mode("expr")
+        self._change_token_scanning_mode("expr")
 
-    def _change_mode(self, mode):
+    def _change_token_scanning_mode(self, mode: str):
         """
-        Set the mode of the tokeniser.
+        Set the kinds of tokens that be will expected on the next token scan.
+        See class variable "modes" above for the dictionary
+        of token-scanning modes.
         """
         self.mode = mode
         self.tokens, self.token_indices = self.modes[mode]
@@ -378,8 +382,10 @@ class Tokeniser(object):
         self.prescanner.incomplete()
         self.code += self.prescanner.replace_escape_sequences()
 
-    def sntx_message(self, pos=None):
-        """Send a message to the feeder."""
+    def sntx_message(self, pos: Optional[int] = None):
+        """
+        Send a "syntx{b,f} error message to the input-reading feeder.
+        """
         if pos is None:
             pos = self.pos
         pre, post = self.code[:pos], self.code[pos:].rstrip("\n")
@@ -388,7 +394,7 @@ class Tokeniser(object):
         else:
             self.feeder.message("Syntax", "sntxf", pre, post)
 
-    # TODO: Convert this to __next__ in the future?
+    # TODO: Convert this to __next__ in the future.
     def next(self) -> "Token":
         "Returns the next token."
         self._skip_blank()
@@ -457,8 +463,48 @@ class Tokeniser(object):
             else:
                 break
 
-    def t_String(self, match) -> "Token":
-        "String rule"
+    def _token_mode(self, match: re.Match, tag: str, mode: str) -> "Token":
+        """
+        Pick out the text in ``match``, convert that into a ``Token``, and
+        return that.
+
+        Also switch token-scanning mode.
+        """
+        text = match.group(0)
+        self.pos = match.end(0)
+        self._change_token_scanning_mode(mode)
+        return Token(tag, text, match.start(0))
+
+    def t_Filename(self, match: re.Match) -> "Token":
+        "Scan for ``Filename`` token and return that"
+        return self._token_mode(match, "Filename", "expr")
+
+    def t_Get(self, match: re.Match) -> "Token":
+        "Scan for a ``Get`` token from ``match`` and return that token"
+        return self._token_mode(match, "Get", "filename")
+
+    def t_Put(self, match: re.Match) -> "Token":
+        "Scan for a ``Put`` token and return that"
+        return self._token_mode(match, "Put", "filename")
+
+    def t_PutAppend(self, match: re.Match) -> "Token":
+        "Scan for a ``PutAppend`` token and return that"
+        return self._token_mode(match, "PutAppend", "filename")
+
+    def t_Number(self, match: re.Match) -> "Token":
+        "Break out from ``match`` the next token which is expected to be a Number"
+        text = match.group(0)
+        pos = match.end(0)
+        if self.code[pos - 1 : pos + 1] == "..":
+            # Trailing .. should be ignored. That is, `1..` is `Repeated[1]`.
+            text = text[:-1]
+            self.pos = pos - 1
+        else:
+            self.pos = pos
+        return Token("Number", text, match.start(0))
+
+    def t_String(self, match: re.Match) -> "Token":
+        "Break out from self.code the next token which is expected to be a String"
         start, end = self.pos, None
         self.pos += 1  # skip opening '"'
         newlines = []
@@ -484,39 +530,3 @@ class Tokeniser(object):
             self.code[indices[i] : indices[i + 1]] for i in range(len(indices) - 1)
         )
         return Token("String", result, start)
-
-    def t_Number(self, match) -> "Token":
-        "Number rule"
-        text = match.group(0)
-        pos = match.end(0)
-        if self.code[pos - 1 : pos + 1] == "..":
-            # Trailing .. should be ignored. That is, `1..` is `Repeated[1]`.
-            text = text[:-1]
-            self.pos = pos - 1
-        else:
-            self.pos = pos
-        return Token("Number", text, match.start(0))
-
-    # This isn't outside of here so it's considered internal
-    def _token_mode(self, match, tag, mode) -> "Token":
-        "consume a token and switch mode"
-        text = match.group(0)
-        self.pos = match.end(0)
-        self._change_mode(mode)
-        return Token(tag, text, match.start(0))
-
-    def t_Get(self, match) -> "Token":
-        "Get rule"
-        return self._token_mode(match, "Get", "filename")
-
-    def t_Put(self, match) -> "Token":
-        "Put rule"
-        return self._token_mode(match, "Put", "filename")
-
-    def t_PutAppend(self, match) -> "Token":
-        "PutAppend rule"
-        return self._token_mode(match, "PutAppend", "filename")
-
-    def t_Filename(self, match) -> "Token":
-        "Filename rule"
-        return self._token_mode(match, "Filename", "expr")

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,17 @@ mathics-users@googlegroups.com and ask for help.
 """
 
 import atexit
-import pkg_resources
+import os.path as osp
+import platform
 import re
 import subprocess
 import sys
-import os.path as osp
-import platform
+
+import pkg_resources
 from setuptools import setup
 
 # Ensure user has the correct Python version
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     print("mathics-scanner does not support Python %d.%d" % sys.version_info[:2])
     sys.exit(-1)
 
@@ -119,7 +120,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
* add isort hook and use it
* run codespell over code
* start adding more annotation types
* Python 3.6 no longer supportable. (It doesn't have `re.Match` like newer versions do.