### PR TITLE
More operator tables

### DIFF
--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -2120,6 +2120,7 @@ DirectedEdge:
   esc-alias: de
   has-unicode-inverse: false
   is-letter-like: false
+  operator-name: DirectedEdge
   unicode-equivalent: "\u2192"
   unicode-equivalent-name: RIGHTWARDS ARROW
   unicode-reference: https://www.compart.com/en/unicode/U+2192

--- a/mathics_scanner/data/operators.yml
+++ b/mathics_scanner/data/operators.yml
@@ -224,7 +224,7 @@ Association:
   # N-tokens: {"<|", ""}
   # L-tokens: e
   # O-tokens: {"|>", ""}
-  usage: "<|expr|>; expr "
+  usage: ["<|expr|>", "expr "]
   # parse: {"Association", "[", "expr", ",", "…", "]"}
   FullForm: Association[expr, \[Ellipsis]]
   arity: n-ary
@@ -716,6 +716,7 @@ CompoundExpression:
   meaningful: true
   # comments:
 
+# rocky: What's this for?
 CompoundExpressionNull:
   actual-precedence: 30
   precedence: 10
@@ -850,7 +851,7 @@ ContextPathSeparator:
   affix:
   associativity: null
   meaningful: true
-  # comments: Functions as a decimal point: either contextpath1 or contextpath2 may be empty, but not both at the same time.
+  # comments: Functions similiar to decimal point for numbers: either contextpath1 or contextpath2 may be empty, but not both at the same time.
 
 ContourIntegral:
   actual-precedence: 420
@@ -1179,7 +1180,7 @@ DirectedEdge:
   FullForm: DirectedEdge[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: "non-associative"
   meaningful: true
   # comments:
 
@@ -2095,7 +2096,7 @@ FractionBox:
   # parse: {"FractionBox", "[", "expr1", ",", "expr2", "]"}
   arity: Binary
   affix: Infix
-  associativity: left
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -4896,7 +4897,7 @@ Optional:
   FullForm: Optional[patt, expr]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -4994,7 +4995,7 @@ OverunderscriptBox:
   # parse: {"UnderoverscriptBox", "[", "expr1", ",", "expr3", ",", "expr2", "]"}
   arity: Ternary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -5189,7 +5190,7 @@ Pattern:
   FullForm: Pattern[symb, expr]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -5203,12 +5204,12 @@ PatternTest:
   # N-tokens: {}
   # L-tokens: {"?"}
   # O-tokens: {}
-  # usage: "expr1 ? expr2"
+  usage: "expr1 ? expr2"
   # parse: {"PatternTest", "[", "expr1", ",", "expr2", "]"}
   FullForm: PatternTest[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: "non-associative"
   meaningful: true
   # comments:
 
@@ -6446,7 +6447,7 @@ Span:
   # N-tokens: {";;"}
   # L-tokens: {";;"}
   # O-tokens: {";;"}
-  usage: ;;,  i;;,; ;;j, ;;;;k, i;;j, i;;;;k, ;;j;;k  i;;j;;k
+  usage: [";;",  "i;;", ";;j", ";;;;k", "i;;j", "i;;;;k", ;";j;;k", "i;;j;;k"]
   # parse: {"Span", "[", "i", ",", "j", ",", "k", "]"}
   FullForm: Span[i, j, k]
   arity: Ternary
@@ -6491,7 +6492,7 @@ SqrtBox:
   FullForm:
   arity: Unary
   affix: Prefix
-  associativity: right
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -6759,7 +6760,7 @@ SubsuperscriptBox:
   FullForm:
   arity: Ternary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -6951,7 +6952,7 @@ SuperscriptBox:
   FullForm:
   arity: Binary
   affix: Infix
-  associativity: right
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -7218,7 +7219,7 @@ Times:
   # N-tokens: {}
   # L-tokens: {"*", "×", "
   # O-tokens: {}
-  usage: x * y, x × y, x y,
+  usage: ["x * y", "x × y", "x y"]
   # parse: {"Times", "[", "expr1", ",", "expr2", "]"}
   FullForm: Times[expr1, expr2]
   arity: Binary
@@ -7381,7 +7382,7 @@ UnderoverscriptBox:
   FullForm:
   arity: Ternary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -7420,7 +7421,7 @@ UndirectedEdge:
   FullForm: UndirectedEdge[u, v]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: "non-associative"
   meaningful: true
   # comments:
 

--- a/mathics_scanner/data/operators.yml
+++ b/mathics_scanner/data/operators.yml
@@ -33,9 +33,12 @@
 # |-> to get treated as one unit and not split into two operators like
 # | and ->. So the precedence of |-> has to be higher than |.
 #
+# Note: When there was a mismatch between Jacobson's table and the old Mathics code,
+# we've used the old Mathics code.
+#
 #
 # arity (https://en.wikipedia.org/wiki/Arity)
-# -----
+# -------------------------------------------
 #
 # A fancy word for how many operands (arguments) the operator takes;
 # it is some sort of positive integer. Acceptable values found in our table
@@ -76,12 +79,14 @@
 #   FullForm: when "usage" exists, the FullForm translation of the example
 
 #   associativity: when two or more of the same operator is used, which group to
-#                 evaluate first. One of:
+#                 evaluate first. This value is used in the Mathics3 parser. The
+#   value should be one of:
 #       - None
-#       - Non
-#       - Right
-#       - Left
-#       - Missing["Unknown"]
+#       - left
+#       - non-associative
+#       - right
+#
+#
 #
 #   meaningful: "true" if WMA defines a meaning for the operator and "false" if not.
 #               See "Operators without Built-in Meanings"
@@ -97,7 +102,7 @@ AddTo:
   # N-tokens: {}
   # L-tokens: {"+="}
   # O-tokens: {}
-  # usage: "expr1 += expr2"
+  usage: "expr1 += expr2"
   # parse: {"AddTo", "[", "expr1", ",", "expr2", "]"}
   FullForm: AddTo[expr1, expr2]
   arity: Binary
@@ -116,18 +121,21 @@ Alternatives:
   # N-tokens: {}
   # L-tokens: {"|"}
   # O-tokens: {}
-  # usage: "p1 | p2"
+  usage: "p1 | p2"
   # parse:  expr2
   FullForm: {"Alternatives", "[", "expr1", ",", "expr2", "]"}
   arity: Alternatives[expr1, expr2]
   affix: Binary
-  associativity: infix
+  associativity: null
   meaningful: none
   # comments: True
 
 And:
   actual-precedence: 290
-  Precedence-Function: 215
+  # Note from Mathics3 code:
+  # HACK: although the should be 215 for all boolean_ops we adjust slightly
+  # to get the subprecedences correct
+  Precedence-Function: 225
   precedence: 220
   WolframLanguageData: 55
   WolframLanguageData-corrected: 55
@@ -136,7 +144,7 @@ And:
   # N-tokens: {}
   # L-tokens: {"&&", "∧"}
   # O-tokens: {}
-  # usage: "expr1 && expr2;  expr1 ∧ expr2"
+  usage: "expr1 && expr2;  expr1 ∧ expr2"
   # parse: {"And", "[", "expr1", ",", "expr2", "]"}
   FullForm: And[expr1, expr2]
   arity: Binary
@@ -156,7 +164,7 @@ AngleBracket:
   # N-tokens: {"〈"}
   # L-tokens: {}
   # O-tokens: {"〉"}
-  # usage: "〈expr〉"
+  usage: "〈expr〉"
   # parse: {"AngleBracket", "[", "expr", ",", "…", "]"}
   FullForm: AngleBracket[expr, \[Ellipsis]]
   arity: n-ary
@@ -176,7 +184,7 @@ Apply:
   # N-tokens: {}
   # L-tokens: {"@@"}
   # O-tokens: {}
-  # usage: "expr1 @@ expr2"
+  usage: "expr1 @@ expr2"
   # parse: {"Apply", "[", "expr1", ",", "expr2", "]"}
   FullForm: Apply[expr1, expr2]
   arity: Binary
@@ -195,7 +203,7 @@ ApplyTo:
   # N-tokens: None
   # L-tokens: None
   # O-tokens: None
-  # # usage: "None"
+  # usage: "None"
   # parse: None
   FullForm: None
   arity: Binary
@@ -215,7 +223,7 @@ Association:
   # N-tokens: {"<|", ""}
   # L-tokens: e
   # O-tokens: {"|>", ""}
-  # usage: "<|expr|>; expr "
+  usage: "<|expr|>; expr "
   # parse: {"Association", "[", "expr", ",", "…", "]"}
   FullForm: Association[expr, \[Ellipsis]]
   arity: n-ary
@@ -235,7 +243,7 @@ AutoMatch:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {""}
-  # usage: " expr "
+  usage: " expr "
   # parse: {"AutoMatch","[","expr","]"}
   FullForm: AutoMatch[expr]
   arity: Unary
@@ -254,7 +262,7 @@ Backslash:
   # N-tokens: {}
   # L-tokens: {"∖"}
   # O-tokens: {}
-  # usage: "expr1 \ expr2"
+  usage: "expr1 \ expr2"
   # parse: {"Backslash", "[", "expr1", ",", "expr2", "]"}
   FullForm: Backslash[expr1, expr2]
   arity: Binary
@@ -273,7 +281,7 @@ Because:
   # N-tokens: {}
   # L-tokens: {"∵"}
   # O-tokens: {}
-  # usage: "expr1 ∵ expr2"
+  usage: "expr1 ∵ expr2"
   # parse: {"Because", "[", "expr1", ",", "expr2", "]"}
   FullForm: Because[expr1, expr2]
   arity: Binary
@@ -293,7 +301,7 @@ BlackLenticularBracket:
   # N-tokens: {"【"}
   # L-tokens: {}
   # O-tokens: {"】"}
-  # usage: "【expr】"
+  usage: "【expr】"
   # parse:
   FullForm:
   arity: Unary
@@ -312,7 +320,7 @@ Blank:
   # N-tokens: {"_"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "_"
+  usage: "_"
   # parse: {"Blank", "[", "]"}
   FullForm: Blank[]
   arity: Nullary
@@ -331,7 +339,7 @@ BlankHead:
   # N-tokens: {"_"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "_expr"
+  usage: "_expr"
   # parse: {"Blank", "[", "expr", "]"}
   FullForm: Blank[expr]
   arity: Unary
@@ -350,7 +358,7 @@ BlankNullSequence:
   # N-tokens: {"___"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "___"
+  usage: "___"
   # parse: {"BlankNullSequence", "[", "]"}
   FullForm: BlankNullSequence[]
   arity: Nullary
@@ -369,7 +377,7 @@ BlankNullSequenceHead:
   # N-tokens: {"___"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "___expr"
+  usage: "___expr"
   # parse: {"BlankNullSequence", "[", "expr", "]"}
   FullForm: BlankNullSequence[expr]
   arity: Unary
@@ -388,7 +396,7 @@ BlankOptional:
   # N-tokens: {"_."}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "_."
+  usage: "_."
   # parse: {"Optional", "[", "Blank", "]"}
   FullForm: Optional[Blank[]]
   arity: Nullary
@@ -407,7 +415,7 @@ BlankSequence:
   # N-tokens: {"__"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "__"
+  usage: "__"
   # parse: {"BlankSequence", "[", "]"}
   FullForm: BlankSequence[]
   arity: Nullary
@@ -426,7 +434,7 @@ BlankSequenceHead:
   # N-tokens: {"__"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "__expr"
+  usage: "__expr"
   # parse: {"BlankSequence", "[", "expr", "]"}
   FullForm: BlankSequence[expr]
   arity: Unary
@@ -446,7 +454,7 @@ BoxGroup:
   # N-tokens: {"\("}
   # L-tokens: {}
   # O-tokens: {"\)"}
-  # usage: "\\(expr\\)"
+  usage: "\\(expr\\)"
   # parse: {“LeftRowBox”, expr, “RightRowBox”]
   FullForm: "\\(expr\\)"
   arity: Unary
@@ -466,7 +474,7 @@ BracketingBar:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {""}
-  # usage: "expr"
+  usage: "expr"
   # parse: {"BracketingBar", "[", "expr", ",", "…", "]"}
   FullForm: BracketingBar[expr, \[Ellipsis]]
   arity: n-ary
@@ -485,7 +493,7 @@ Cap:
   # N-tokens: {}
   # L-tokens: {"⌢"}
   # O-tokens: {}
-  # usage: "expr1 ⌢ expr2"
+  usage: "expr1 ⌢ expr2"
   # parse: {"Cap", "[", "expr1", ",", "expr2", "]"}
   FullForm: Cap[expr1, expr2]
   arity: Binary
@@ -505,7 +513,7 @@ CapitalDifferentialD:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "x"
+  usage: "x"
   # parse: {"CapitalDifferentialD", "[", "x", "]"}
   FullForm: CapitalDifferentialD[x]
   arity: Unary
@@ -525,7 +533,7 @@ Ceiling:
   # N-tokens: {"⌈"}
   # L-tokens: {}
   # O-tokens: {"⌉"}
-  # usage: "⌈expr⌉"
+  usage: "⌈expr⌉"
   # parse: {"Ceiling", "[", "expr", "]"}
   FullForm: Ceiling[expr]
   arity: Unary
@@ -544,7 +552,7 @@ CenterDot:
   # N-tokens: {}
   # L-tokens: {"·"}
   # O-tokens: {}
-  # usage: "x · y"
+  usage: "x · y"
   # parse: {"CenterDot", "[", "x", ",", "y", "]"}
   FullForm: CenterDot[x, y]
   arity: Binary
@@ -563,7 +571,7 @@ CircleDot:
   # N-tokens: {}
   # L-tokens: {"⊙"}
   # O-tokens: {}
-  # usage: "expr1 ⊙ expr2"
+  usage: "expr1 ⊙ expr2"
   # parse: {"CircleDot", "[", "expr1", ",", "expr2", "]"}
   FullForm: CircleDot[expr1, expr2]
   arity: Binary
@@ -582,7 +590,7 @@ CircleMinus:
   # N-tokens: {}
   # L-tokens: {"⊖"}
   # O-tokens: {}
-  # usage: "expr1 ⊖ expr2"
+  usage: "expr1 ⊖ expr2"
   # parse: {"CircleMinus", "[", "expr1", ",", "expr2", "]"}
   FullForm: CircleMinus[expr1, expr2]
   arity: Binary
@@ -601,7 +609,7 @@ CirclePlus:
   # N-tokens: {}
   # L-tokens: {"⊕"}
   # O-tokens: {}
-  # usage: "expr1 ⊕ expr1"
+  usage: "expr1 ⊕ expr1"
   # parse: {"CirclePlus", "[", "expr1", ",", "expr2", "]"}
   FullForm: CirclePlus[expr1, expr2]
   arity: Binary
@@ -620,7 +628,7 @@ CircleTimes:
   # N-tokens: {}
   # L-tokens: {"⊗"}
   # O-tokens: {}
-  # usage: "expr1 ⊗ expr2"
+  usage: "expr1 ⊗ expr2"
   # parse: {"CircleTimes", "[", "expr1", ",", "expr2", "]"}
   FullForm: CircleTimes[expr1, expr2]
   arity: Binary
@@ -640,7 +648,7 @@ ClockwiseContourIntegral:
   # N-tokens: {"∲"}
   # L-tokens: {}
   # O-tokens: {""}
-  # usage: "∲ f(x) x"
+  usage: "∲ f(x) x"
   # parse: {"ClockwiseContourIntegral", "[", "expr1", ",", "expr2", "]"}
   FullForm: Integrate[expr1, expr2]
   arity: Binary
@@ -659,7 +667,7 @@ Colon:
   # N-tokens: {}
   # L-tokens: {"∶"}
   # O-tokens: {}
-  # usage: "expr1 ∶ expr2"
+  usage: "expr1 ∶ expr2"
   # parse: {"Colon", "[", "expr1", ",", "expr2", "]"}
   FullForm: Colon[expr1, expr2]
   arity: Binary
@@ -679,7 +687,7 @@ Composition:
   # N-tokens: {}
   # L-tokens: {"@*"}
   # O-tokens: {}
-  # usage: "expr1 @* expr2"
+  usage: "expr1 @* expr2"
   # parse: {"Composition", "[", "expr1", ",", "expr2", "]"}
   FullForm: Composition[expr1, expr2]
   arity: Binary
@@ -696,9 +704,9 @@ CompoundExpression:
   UnicodeCharacters.tr:
   UnicodeCharacters-corrected.tr: 170
   # N-tokens: {}
-  # L-tokens: {";"}
+  # L-tokens: {","}
   # O-tokens: {}
-  # usage: "expr1, expr2"
+  usage: "expr1, expr2"
   # parse: {"CompoundExpression", "[", "expr1", ",", "expr2", "]"}
   FullForm: CompoundExpression[expr1, expr2]
   arity: Binary
@@ -736,7 +744,7 @@ Condition:
   # N-tokens: {}
   # L-tokens: {"/;"}
   # O-tokens: {}
-  # usage: "expr1 /; expr2"
+  usage: "expr1 /; expr2"
   # parse: {"Condition", "[", "expr1", ",", "expr2", "]"}
   FullForm: Condition[expr1, expr2]
   arity: Binary
@@ -755,7 +763,7 @@ Conditioned:
   # N-tokens: {}
   # L-tokens: {""}
   # O-tokens: {}
-  # usage: "expr  cond"
+  usage: "expr  cond"
   # parse: {"Conditioned", "[", "expr", ",", "cond", "]"}
   FullForm: Conditioned[expr, cond]
   arity: Binary
@@ -774,7 +782,7 @@ Congruent:
   # N-tokens: {}
   # L-tokens: {"≡"}
   # O-tokens: {}
-  # usage: "x ≡ y"
+  usage: "x ≡ y"
   # parse: {"Congruent", "[", "x", ",", "y", "]"}
   FullForm: Congruent[x, y]
   arity: Binary
@@ -794,7 +802,7 @@ Conjugate:
   # N-tokens: {}
   # L-tokens: {""}
   # O-tokens: {}
-  # usage: "z"
+  usage: "z"
   # parse: {"Conjugate", "[", "z", "]"}
   FullForm: Conjugate[z]
   arity: Unary
@@ -814,7 +822,7 @@ ConjugateTranspose:
   # N-tokens: {}
   # L-tokens: {"", ""}
   # O-tokens: {}
-  # usage: "m; m"
+  usage: "m; m"
   # parse: {"ConjugateTranspose", "[", "m", "]"}
   FullForm: ConjugateTranspose[m]
   arity: Unary
@@ -834,7 +842,7 @@ ContextPathSeparator:
   # N-tokens: {}
   # L-tokens: {"`"}
   # O-tokens: {}
-  # usage: "symb1`symb2"
+  usage: "symb1`symb2"
   # parse: {"symb1", "`", "symb2"}
   FullForm: symb1`symb2
   arity:
@@ -854,7 +862,7 @@ ContourIntegral:
   # N-tokens: {"∮"}
   # L-tokens: {}
   # O-tokens: {""}
-  # usage: "∮ f(x) x"
+  usage: "∮ f(x) x"
   # parse: {"ContourIntegral", "[", "expr1", ",", "expr2", "]"}
   FullForm: Integrate[expr1, expr2]
   arity: Binary
@@ -873,7 +881,7 @@ Coproduct:
   # N-tokens: {}
   # L-tokens: {"∐"}
   # O-tokens: {}
-  # usage: "expr1 ∐ expr2"
+  usage: "expr1 ∐ expr2"
   # parse: {"Coproduct", "[", "expr1", ",", "expr2", "]"}
   FullForm: Coproduct[expr1, expr2]
   arity: Binary
@@ -893,7 +901,7 @@ CornerBracket:
   # N-tokens: {"「"}
   # L-tokens: {}
   # O-tokens: {"」"}
-  # usage: "「expr」"
+  usage: "「expr」"
   # parse:
   FullForm:
   arity: Unary
@@ -913,7 +921,7 @@ CounterClockwiseContourIntegral:
   # N-tokens: {"∳"}
   # L-tokens: {}
   # O-tokens: {""}
-  # usage: "∳ f(x)  x"
+  usage: "∳ f(x)  x"
   # parse: {"CounterClockwiseContourIntegral", "[", "expr1", ",", "expr2", "]"}
   FullForm: Integrate[expr1, expr2]
   arity: Binary
@@ -932,7 +940,7 @@ Cross:
   # N-tokens: {}
   # L-tokens: {""}
   # O-tokens: {}
-  # usage: "expr1  expr2"
+  usage: "expr1  expr2"
   # parse: {"Cross", "[", "expr1", ",", "expr2", "]"}
   FullForm: Cross[expr1, expr2]
   arity: Binary
@@ -951,7 +959,7 @@ Cup:
   # N-tokens: {}
   # L-tokens: {"⌣"}
   # O-tokens: {}
-  # usage: "expr1 ⌣ expr2"
+  usage: "expr1 ⌣ expr2"
   # parse: {"Cup", "[", "expr1", ",", "expr2", "]"}
   FullForm: Cup[expr1, expr2]
   arity: Binary
@@ -970,7 +978,7 @@ CupCap:
   # N-tokens: {}
   # L-tokens: {"≍"}
   # O-tokens: {}
-  # usage: "x ≍ y"
+  usage: "x ≍ y"
   # parse: {"CupCap", "[", "x", ",", "y", "]"}
   FullForm: CupCap[x, y]
   arity: Binary
@@ -990,7 +998,7 @@ Curl:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "expr"
+  usage: "expr"
   # parse: {"Curl", "[", "expr", "]"}
   FullForm:
   arity: Unary
@@ -1010,7 +1018,7 @@ CurlyDoubleQuote:
   # N-tokens: {"“"}
   # L-tokens: {}
   # O-tokens: {"”"}
-  # usage: "“expr”"
+  usage: "“expr”"
   # parse: {"CurlyDoubleQuote","[","expr","]"}
   FullForm: CurlyDoubleQuote[expr]
   arity: Unary
@@ -1050,7 +1058,7 @@ Decrement:
   # N-tokens: {}
   # L-tokens: {"--"}
   # O-tokens: {}
-  # usage: "expr--"
+  usage: "expr--"
   # parse: {"Decrement", "[", "expr", "]"}
   FullForm: Decrement[expr]
   arity: Unary
@@ -1069,7 +1077,7 @@ Del:
   # N-tokens: {"∇"}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "∇x"
+  usage: "∇x"
   # parse: {"Del", "[", "expr", "]"}
   FullForm: Del[expr]
   arity: Unary
@@ -1107,7 +1115,7 @@ Diamond:
   # N-tokens: {}
   # L-tokens: {"⋄"}
   # O-tokens: {}
-  # usage: "expr1 ⋄ expr2"
+  usage: "expr1 ⋄ expr2"
   # parse: {"Diamond", "[", "expr1", ",", "expr2", "]"}
   FullForm: Diamond[expr1, expr2]
   arity: Binary
@@ -1126,7 +1134,7 @@ DifferenceDelta:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "expr"
+  usage: "expr"
   # parse: {"DifferenceDelta", "[", "expr", "]"}
   FullForm:
   arity: Unary
@@ -1146,7 +1154,7 @@ DifferentialD:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "x"
+  usage: "x"
   # parse: {"DifferentialD", "[", "x", "]"}
   FullForm: DifferentialD[x]
   arity: Unary
@@ -1157,20 +1165,20 @@ DifferentialD:
 
 DirectedEdge:
   actual-precedence: 370
-  precedence: 295
+  precedence: 128
   WolframLanguageData:
   WolframLanguageData-corrected: 49
   UnicodeCharacters.tr: 395
   UnicodeCharacters-corrected.tr: 395
   # N-tokens: {}
-  # L-tokens: {""}
+  # L-tokens: {"→"}
   # O-tokens: {}
-  # usage: "u  v"
+  usage: "u → v"
   # parse: {"DirectedEdge", "[", "u", ",", "v", "]"}
   FullForm: DirectedEdge[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: non-associative
   meaningful: true
   # comments:
 
@@ -1184,7 +1192,7 @@ DiscreteRatio:
   # N-tokens: {""}
   # L-tokens: {}
   # O-tokens: {}
-  # usage: "f  i"
+  usage: "f  i"
   # parse: {"DiscreteRatio", "[", "f", "i", "]"}
   FullForm:
   arity: Unary
@@ -5181,7 +5189,7 @@ PatternTest:
   FullForm: PatternTest[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: non-associative
   meaningful: true
   # comments:
 
@@ -7380,20 +7388,20 @@ UnderscriptBox:
 
 UndirectedEdge:
   actual-precedence: 370
-  precedence: 295
+  precedence: 120
   WolframLanguageData:
   WolframLanguageData-corrected: 49
   UnicodeCharacters.tr: 395
   UnicodeCharacters-corrected.tr: 395
   # N-tokens: {}
-  # L-tokens: {""}
+  # L-tokens: {"↔"}
   # O-tokens: {}
-  # usage: "expr1  expr2"
-  # parse: {"UndirectedEdge", "[", "expr1", ",", "expr2", "]"}
-  FullForm: UndirectedEdge[expr1, expr2]
+  usage: "u ↔ v"
+  # parse: {"UndirectedEdge", "[", "u", ",", "v", "]"}
+  FullForm: UndirectedEdge[u, v]
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: non-associative
   meaningful: true
   # comments:
 

--- a/mathics_scanner/data/operators.yml
+++ b/mathics_scanner/data/operators.yml
@@ -85,6 +85,7 @@
 #       - left
 #       - non-associative
 #       - right
+#       - unknown
 #
 #
 #
@@ -136,7 +137,7 @@ And:
   # HACK: although the should be 215 for all boolean_ops we adjust slightly
   # to get the subprecedences correct
   Precedence-Function: 225
-  precedence: 220
+  precedence: 225
   WolframLanguageData: 55
   WolframLanguageData-corrected: 55
   UnicodeCharacters.tr: 330
@@ -176,7 +177,7 @@ AngleBracket:
 Apply:
   actual-precedence: 820
   Precedence-Function: 620
-  precedence: 626
+  precedence: 620
   WolframLanguageData: 16
   WolframLanguageData-corrected: 16
   UnicodeCharacters.tr:
@@ -595,7 +596,7 @@ CircleMinus:
   FullForm: CircleMinus[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: left
+  associativity: null
   meaningful: false
   # comments:
 
@@ -679,7 +680,7 @@ Colon:
 Composition:
   actual-precedence: 860
   Precedence-Function: 625
-  precedence: 655
+  precedence: 625
   WolframLanguageData: 13
   WolframLanguageData-corrected: 13
   UnicodeCharacters.tr:
@@ -794,7 +795,7 @@ Congruent:
 Conjugate:
   actual-precedence: 780
   Precedence-Function: 670
-  precedence: 605
+  precedence: 670
   WolframLanguageData: 18
   WolframLanguageData-corrected: 18
   UnicodeCharacters.tr: 695
@@ -814,7 +815,7 @@ Conjugate:
 ConjugateTranspose:
   actual-precedence: 780
   Precedence-Function: 670
-  precedence: 605
+  precedence: 670
   WolframLanguageData: 18
   WolframLanguageData-corrected: 18
   UnicodeCharacters.tr: 695
@@ -1050,7 +1051,7 @@ CurlyQuote:
 Decrement:
   actual-precedence: 880
   Precedence-Function: 660
-  precedence: 665
+  precedence: 660
   WolframLanguageData: 11
   WolframLanguageData-corrected: 11
   UnicodeCharacters.tr:
@@ -1178,7 +1179,7 @@ DirectedEdge:
   FullForm: DirectedEdge[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: non-associative
+  associativity: null
   meaningful: true
   # comments:
 
@@ -2075,7 +2076,7 @@ FormBox:
   # parse: {"FormBox", "[", "expr2", ",", "expr1", "]"}
   arity: Binary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -2540,7 +2541,7 @@ Implies:
 Increment:
   actual-precedence: 880
   Precedence-Function: 660
-  precedence: 665
+  precedence: 660
   WolframLanguageData: 11
   WolframLanguageData-corrected: 11
   UnicodeCharacters.tr:
@@ -2557,9 +2558,27 @@ Increment:
   meaningful: true
   # comments:
 
+Infix:
+  precedence: 630
+  WolframLanguageData: None
+  WolframLanguageData-corrected: None
+  UnicodeCharacters.tr: None
+  UnicodeCharacters-corrected.tr: None
+  # N-tokens: None
+  # L-tokens: None
+  # O-tokens: None
+  usage: x ~ f ~ y
+  # parse: Infix[f[x, y]]
+  FullForm: None
+  arity: Ternary
+  affix: Infix
+  associativity: null
+  meaningful: true
+  # comments: None
+
 Information:
   actual-precedence: 670
-  precedence: 670
+  precedence: 5001  # Seems a bit extreme. This is the old Mathics data
   WolframLanguageData: None
   WolframLanguageData-corrected: None
   UnicodeCharacters.tr: None
@@ -2570,8 +2589,8 @@ Information:
   # usage: "None"
   # parse: None
   FullForm: None
-  arity: Binary
-  affix: Infix
+  arity: Unary
+  affix: Prefix
   associativity: null
   meaningful: true
   # comments: None
@@ -3682,7 +3701,7 @@ NamedBlankSequenceHead:
 Nand:
   actual-precedence: 290
   Precedence-Function: 215
-  precedence: 220
+  precedence: 225
   WolframLanguageData: 55
   WolframLanguageData-corrected: 55
   UnicodeCharacters.tr: 330
@@ -3759,7 +3778,7 @@ NonCommutativeMultiply:
 Nor:
   actual-precedence: 270
   Precedence-Function: 215
-  precedence: 210
+  precedence: 215
   WolframLanguageData: 57
   WolframLanguageData-corrected: 57
   UnicodeCharacters.tr: 320
@@ -4884,7 +4903,7 @@ Optional:
 Or:
   actual-precedence: 270
   Precedence-Function: 215
-  precedence: 210
+  precedence: 215
   WolframLanguageData: 57
   WolframLanguageData-corrected: 57
   UnicodeCharacters.tr: 320
@@ -4956,7 +4975,7 @@ OverscriptBox:
   # parse: {"OverscriptBox", "[", "expr1", ",", "expr2", "]"}
   arity: Binary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -5189,7 +5208,7 @@ PatternTest:
   FullForm: PatternTest[expr1, expr2]
   arity: Binary
   affix: Infix
-  associativity: non-associative
+  associativity: null
   meaningful: true
   # comments:
 
@@ -5292,7 +5311,7 @@ PlusMinus:
 
 Postfix:
   actual-precedence: 640
-  precedence: 640
+  precedence: 70  # Seems weird but this is what old Mathics code has
   WolframLanguageData: None
   WolframLanguageData-corrected: None
   UnicodeCharacters.tr: None
@@ -5305,7 +5324,7 @@ Postfix:
   FullForm: None
   arity: Binary
   affix: Infix
-  associativity: null
+  associativity: left
   meaningful: true
   # comments: None
 
@@ -6171,7 +6190,7 @@ RuleDelayed:
 SameQ:
   actual-precedence: 330
   Precedence-Function: 290
-  precedence: 260
+  precedence: 290
   WolframLanguageData: 51
   WolframLanguageData-corrected: 51
   UnicodeCharacters.tr:
@@ -6427,7 +6446,7 @@ Span:
   # N-tokens: {";;"}
   # L-tokens: {";;"}
   # O-tokens: {";;"}
-  # usage: "i", ";;", "j ;; k"
+  usage: ;;,  i;;,; ;;j, ;;;;k, i;;j, i;;;;k, ;;j;;k  i;;j;;k
   # parse: {"Span", "[", "i", ",", "j", ",", "k", "]"}
   FullForm: Span[i, j, k]
   arity: Ternary
@@ -6682,7 +6701,7 @@ SubscriptBox:
   FullForm:
   arity: Binary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -7199,11 +7218,11 @@ Times:
   # N-tokens: {}
   # L-tokens: {"*", "×", "
   # O-tokens: {}
-  # usage: "{{"expr1", "*", "expr2"}, {"expr1", "expr2"}, {"expr1", "×", "expr2"}, {"expr1", ""
+  usage: x * y, x × y, x y,
   # parse: {"Times", "[", "expr1", ",", "expr2", "]"}
   FullForm: Times[expr1, expr2]
-  arity: Nullary
-  affix: None
+  arity: Binary
+  affix: Infix
   associativity: null
   meaningful: true
   # comments: Operator Notations includes usages with invisible unicode characters.
@@ -7250,7 +7269,7 @@ TortoiseShellBracket:
 Transpose:
   actual-precedence: 780
   Precedence-Function: 670
-  precedence: 605
+  precedence: 670
   WolframLanguageData: 18
   WolframLanguageData-corrected: 18
   UnicodeCharacters.tr: 695
@@ -7382,7 +7401,7 @@ UnderscriptBox:
   FullForm:
   arity: Binary
   affix: Infix
-  associativity: missing["unknown"]
+  associativity: "unknown"
   meaningful: true
   # comments:
 
@@ -7401,7 +7420,7 @@ UndirectedEdge:
   FullForm: UndirectedEdge[u, v]
   arity: Binary
   affix: Infix
-  associativity: non-associative
+  associativity: null
   meaningful: true
   # comments:
 
@@ -7465,7 +7484,7 @@ UnionPlus:
 UnsameQ:
   actual-precedence: 330
   Precedence-Function: 290
-  precedence: 260
+  precedence: 290
   WolframLanguageData: 51
   WolframLanguageData-corrected: 51
   UnicodeCharacters.tr:
@@ -7485,7 +7504,7 @@ UnsameQ:
 Unset:
   actual-precedence: 50
   Precedence-Function: 670
-  precedence: 40
+  precedence: 670
   WolframLanguageData: 75
   WolframLanguageData-corrected: 75
   UnicodeCharacters.tr:
@@ -7828,7 +7847,7 @@ WhiteCornerBracket:
 
 Xnor:
   actual-precedence: 280
-  precedence: 215
+  precedence: 220
   WolframLanguageData: 56
   WolframLanguageData-corrected: 56
   UnicodeCharacters.tr: 325
@@ -7847,7 +7866,7 @@ Xnor:
 
 Xor:
   actual-precedence: 280
-  precedence: 215
+  precedence: 220
   WolframLanguageData: 56
   WolframLanguageData-corrected: 56
   UnicodeCharacters.tr: 325

--- a/mathics_scanner/data/operators.yml
+++ b/mathics_scanner/data/operators.yml
@@ -145,7 +145,7 @@ And:
   # N-tokens: {}
   # L-tokens: {"&&", "∧"}
   # O-tokens: {}
-  usage: "expr1 && expr2;  expr1 ∧ expr2"
+  usage: ["expr1 && expr2", "expr1 ∧ expr2"]
   # parse: {"And", "[", "expr1", ",", "expr2", "]"}
   FullForm: And[expr1, expr2]
   arity: Binary
@@ -4912,7 +4912,7 @@ Or:
   # N-tokens: {}
   # L-tokens: {"||", "∨"}
   # O-tokens: {}
-  # usage: "expr1", "||", "expr2"}, {"expr1 ∨ expr2"
+  usage: ["x || y", "x ∨ y"]
   # parse: {"Or", "[", "expr1", ",", "expr2", "]"}
   FullForm: Or[expr1, expr2]
   arity: Binary
@@ -7397,7 +7397,7 @@ UnderscriptBox:
   # N-tokens: {}
   # L-tokens: {"\+"}
   # O-tokens: {}
-  # usage: "expr1 \+ expr2"
+  usage: "expr1 \\+ expr2"
   # parse: {"UnderscriptBox", "[", "expr1", ",", "expr2", "]"}
   FullForm:
   arity: Binary
@@ -7435,7 +7435,7 @@ Unequal:
   # N-tokens: {}
   # L-tokens: {"!=", "≠"}
   # O-tokens: {}
-  # usage: "expr1", "!=", "expr2"}, {"expr1 ≠ expr2"
+  usage: ["x != y", "x ≠ y"]
   # parse: {"Unequal", "[", "expr1", ",", "expr2", "]"}
   FullForm: Unequal[expr1, expr2]
   arity: Binary
@@ -7454,7 +7454,7 @@ Union:
   # N-tokens: {}
   # L-tokens: {"⋃"}
   # O-tokens: {}
-  # usage: "expr1 ⋃ expr2"
+  usage: "expr1 ⋃ expr2"
   # parse: {"Union", "[", "expr1", ",", "expr2", "]"}
   FullForm: Union[expr1, expr2]
   arity: Binary
@@ -7473,7 +7473,7 @@ UnionPlus:
   # N-tokens: {}
   # L-tokens: {"⊎"}
   # O-tokens: {}
-  # usage: "x ⊎ y"
+  usage: "x ⊎ y"
   # parse: {"UnionPlus", "[", "x", ",", "y", "]"}
   FullForm: UnionPlus[x, y]
   arity: Binary
@@ -7493,7 +7493,7 @@ UnsameQ:
   # N-tokens: {}
   # L-tokens: {"=!="}
   # O-tokens: {}
-  # usage: "expr1 =!= expr2"
+  usage: "expr1 =!= expr2"
   # parse: {"UnsameQ", "[", "expr1", ",", "expr2", "]"}
   FullForm: UnsameQ[expr1, expr2]
   arity: Binary
@@ -7532,7 +7532,7 @@ UpArrow:
   # N-tokens: {}
   # L-tokens: {"↑"}
   # O-tokens: {}
-  # usage: "x ↑ y"
+  usage: "x ↑ y"
   # parse: {"UpArrow", "[", "x", ",", "y", "]"}
   FullForm: UpArrow[x, y]
   arity: Binary
@@ -7551,7 +7551,7 @@ UpArrowBar:
   # N-tokens: {}
   # L-tokens: {"⤒"}
   # O-tokens: {}
-  # usage: "x ⤒ y"
+  usage: "x ⤒ y"
   # parse: {"UpArrowBar", "[", "x", ",", "y", "]"}
   FullForm: UpArrowBar[x, y]
   arity: Binary
@@ -7570,7 +7570,7 @@ UpArrowDownArrow:
   # N-tokens: {}
   # L-tokens: {"⇅"}
   # O-tokens: {}
-  # usage: "x ⇅ y"
+  usage: "x ⇅ y"
   # parse: {"UpArrowDownArrow", "[", "x", ",", "y", "]"}
   FullForm: UpArrowDownArrow[x, y]
   arity: Binary
@@ -7589,7 +7589,7 @@ UpDownArrow:
   # N-tokens: {}
   # L-tokens: {"↕"}
   # O-tokens: {}
-  # usage: "x ↕ y"
+  usage: "x ↕ y"
   # parse: {"UpDownArrow", "[", "x", ",", "y", "]"}
   FullForm: UpDownArrow[x, y]
   arity: Binary
@@ -7608,7 +7608,7 @@ UpEquilibrium:
   # N-tokens: {}
   # L-tokens: {"⥮"}
   # O-tokens: {}
-  # usage: "x ⥮ y"
+  usage: "x ⥮ y"
   # parse: {"UpEquilibrium", "[", "x", ",", "y", "]"}
   FullForm: UpEquilibrium[x, y]
   arity: Binary
@@ -7627,7 +7627,7 @@ UpSet:
   # N-tokens: {}
   # L-tokens: {"^="}
   # O-tokens: {}
-  # usage: "expr1 ^= expr2"
+  usage: "expr1 ^= expr2"
   # parse: {"UpSet", "[", "expr1", ",", "expr2", "]"}
   FullForm: UpSet[expr1, expr2]
   arity: Binary
@@ -7646,7 +7646,7 @@ UpSetDelayed:
   # N-tokens: {}
   # L-tokens: {"^:="}
   # O-tokens: {}
-  # usage: "expr1 ^:= expr2"
+  usage: "expr1 ^:= expr2"
   # parse: {"UpSetDelayed", "[", "expr1", ",", "expr2", "]"}
   FullForm: UpSetDelayed[expr1, expr2]
   arity: Binary
@@ -7665,7 +7665,7 @@ UpTee:
   # N-tokens: {}
   # L-tokens: {"⊥"}
   # O-tokens: {}
-  # usage: "expr1 ⊥ expr2"
+  usage: "expr1 ⊥ expr2"
   # parse: {"UpTee", "[", "expr1", ",", "expr2", "]"}
   FullForm: UpTee[expr1, expr2]
   arity: Binary
@@ -7684,7 +7684,7 @@ UpTeeArrow:
   # N-tokens: {}
   # L-tokens: {"↥"}
   # O-tokens: {}
-  # usage: "x ↥ y"
+  usage: "x ↥ y"
   # parse: {"UpTeeArrow", "[", "x", ",", "y", "]"}
   FullForm: UpTeeArrow[x, y]
   arity: Binary
@@ -7703,7 +7703,7 @@ UpperLeftArrow:
   # N-tokens: {}
   # L-tokens: {"↖"}
   # O-tokens: {}
-  # usage: "x ↖ y"
+  usage: "x ↖ y"
   # parse: {"UpperLeftArrow", "[", "x", ",", "y", "]"}
   FullForm: UpperLeftArrow[x, y]
   arity: Binary
@@ -7722,7 +7722,7 @@ UpperRightArrow:
   # N-tokens: {}
   # L-tokens: {"↗"}
   # O-tokens: {}
-  # usage: "x ↗ y"
+  usage: "x ↗ y"
   # parse: {"UpperRightArrow", "[", "x", ",", "y", "]"}
   FullForm: UpperRightArrow[x, y]
   arity: Binary
@@ -7741,7 +7741,7 @@ Vee:
   # N-tokens: {}
   # L-tokens: {"⋁"}
   # O-tokens: {}
-  # usage: "x ⋁ y"
+  usage: "x ⋁ y"
   # parse: {"Vee", "[", "x", ",", "y", "]"}
   FullForm: Vee[x, y]
   arity: Binary
@@ -7760,7 +7760,7 @@ VerticalBar:
   # N-tokens: {}
   # L-tokens: {""}
   # O-tokens: {}
-  # usage: "expr1  expr2"
+  usage: "expr1  expr2"
   # parse: {"VerticalBar", "[", "expr1", ",", "expr2", "]"}
   FullForm: VerticalBar[expr1, expr2]
   arity: Binary
@@ -7779,7 +7779,7 @@ VerticalSeparator:
   # N-tokens: {}
   # L-tokens: {""}
   # O-tokens: {}
-  # usage: "expr1  expr2"
+  usage: "expr1  expr2"
   # parse: {"VerticalSeparator", "[", "expr1", ",", "expr2", "]"}
   FullForm: VerticalSeparator[expr1, expr2]
   arity: Binary
@@ -7798,7 +7798,7 @@ VerticalTilde:
   # N-tokens: {}
   # L-tokens: {"≀"}
   # O-tokens: {}
-  # usage: "expr1 ≀ expr2"
+  usage: "expr1 ≀ expr2"
   # parse: {"VerticalTilde", "[", "expr1", ",", "expr2", "]"}
   FullForm: VerticalTilde[expr1, expr2]
   arity: Binary
@@ -7817,7 +7817,7 @@ Wedge:
   # N-tokens: {}
   # L-tokens: {"⋀"}
   # O-tokens: {}
-  # usage: "expr1 ⋀ expr2"
+  usage: "expr1 ⋀ expr2"
   # parse: {"Wedge", "[", "expr1", ",", "expr2", "]"}
   FullForm: Wedge[expr1, expr2]
   arity: Binary
@@ -7837,7 +7837,7 @@ WhiteCornerBracket:
   # N-tokens: {"『"}
   # L-tokens: {}
   # O-tokens: {"』"}
-  # usage: "『 expr 』"
+  usage: "『 expr 』"
   # parse:
   FullForm:
   arity: Unary
@@ -7856,7 +7856,7 @@ Xnor:
   # N-tokens: {}
   # L-tokens: {""}
   # O-tokens: {}
-  # usage: "expr1  expr2"
+  usage: "x1  y"
   # parse: {"Xnor", "[", "expr1", ",", "expr2", "]"}
   FullForm: Xnor[expr1, expr2]
   arity: Binary
@@ -7875,7 +7875,7 @@ Xor:
   # N-tokens: {}
   # L-tokens: {"⊻"}
   # O-tokens: {}
-  # usage: "expr1 ⊻ expr2"
+  usage: "x ⊻ y"
   # parse: {"Xor", "[", "expr1", ",", "expr2", "]"}
   FullForm: Xor[expr1, expr2]
   arity: Binary

--- a/mathics_scanner/data/operators.yml
+++ b/mathics_scanner/data/operators.yml
@@ -5311,7 +5311,7 @@ PlusMinus:
 
 Postfix:
   actual-precedence: 640
-  precedence: 70  # Seems weird but this is what old Mathics code has
+  precedence: 70
   WolframLanguageData: None
   WolframLanguageData-corrected: None
   UnicodeCharacters.tr: None
@@ -7407,7 +7407,7 @@ UnderscriptBox:
 
 UndirectedEdge:
   actual-precedence: 370
-  precedence: 120
+  precedence: 120 # FIXME: is probably 295. Check and adjust after code and mathics-core are merge
   WolframLanguageData:
   WolframLanguageData-corrected: 49
   UnicodeCharacters.tr: 395
@@ -7866,7 +7866,7 @@ Xnor:
 
 Xor:
   actual-precedence: 280
-  precedence: 220
+  precedence: 220 # FIXME: is probably 215. Check and adjust after code and mathics-core are merged
   WolframLanguageData: 56
   WolframLanguageData-corrected: 56
   UnicodeCharacters.tr: 325

--- a/mathics_scanner/generate/build_operator_tables.py
+++ b/mathics_scanner/generate/build_operator_tables.py
@@ -97,17 +97,14 @@ def compile_tables(
         elif affix == "Postfix":
             operator_dict = postfix_operators
 
+        if operator_dict is not None:
+            operator_dict[operator_name] = precedence
+
         character_info = character_data.get(operator_name)
         if character_info is None:
-            unicode_char = "no-unicode"
-        else:
-            unicode_char = character_info.get("unicode-equivalent", "no-unicode")
-
-        if operator_dict is not None:
-            operator_dict[operator_name] = unicode_char, precedence
-
-        if character_info is None:
             continue
+
+        unicode_char = character_info.get("unicode-equivalent", "no-unicode")
 
         if operator_info.get("meaningful", True) is False and (
             character_data.get(operator_name)
@@ -119,20 +116,21 @@ def compile_tables(
 
             affix = operator_info["affix"]
             if affix == "Infix":
-                no_meaning_infix_operators[operator_name] = unicode_char
+                no_meaning_infix_operators[operator_name] = unicode_char, precedence
             elif affix == "Postfix":
-                no_meaning_postfix_operators[operator_name] = unicode_char
+                no_meaning_postfix_operators[operator_name] = unicode_char, precedence
             elif affix == "Prefix":
-                no_meaning_prefix_operators[operator_name] = unicode_char
+                no_meaning_prefix_operators[operator_name] = unicode_char, precedence
             else:
                 print(f"FIXME: affix {affix} of {operator_name} not handled")
 
     return {
         "flat-binary-operators": flat_binary_operators,
         "left-binary-operators": left_binary_operators,
-        "misc-ops": misc_operators,
+        "miscellaneous-operators": misc_operators,
         "no-meaning-infix-operators": no_meaning_infix_operators,
         "no-meaning-postfix-operators": no_meaning_postfix_operators,
+        "no-meaning-prefix-operators": no_meaning_prefix_operators,
         "non-associative-binary-operators": nonassoc_binary_operators,
         "operator-precedence": operator_precedence,
         "postfix-operators": postfix_operators,

--- a/mathics_scanner/generate/build_operator_tables.py
+++ b/mathics_scanner/generate/build_operator_tables.py
@@ -68,12 +68,13 @@ def compile_tables(
                 continue
 
             affix = operator_info["affix"]
+            precedence = operator_info["precedence"]
             if affix == "Infix":
-                no_meaning_infix_operators[operator_name] = unicode_char
+                no_meaning_infix_operators[operator_name] = unicode_char, precedence
             elif affix == "Postfix":
-                no_meaning_postfix_operators[operator_name] = unicode_char
+                no_meaning_postfix_operators[operator_name] = unicode_char, precedence
             elif affix == "Prefix":
-                no_meaning_prefix_operators[operator_name] = unicode_char
+                no_meaning_prefix_operators[operator_name] = unicode_char, precedence
             else:
                 print(f"FIXME: affix {affix} of {operator_name} not handled")
     return {


### PR DESCRIPTION
Most of the information we will need in mathics-core to revise `mathics.core.parser.operators`.