### PR TITLE
String tokenization fix

### DIFF
--- a/mathics_scanner/feed.py
+++ b/mathics_scanner/feed.py
@@ -47,7 +47,8 @@ class LineFeeder(metaclass=ABCMeta):
     def message(self, symbol_name: str, tag: str, *args) -> None:
         """
 
-         A Generic message appending routine. the ``self.messages`` message queue.
+        A Generic routine for appending a message to the ``self.messages`` message
+        queue.
 
         ``symbol_name`` is usually the string symbol name of the built-in function that
         is recording the error. "Syntax" error is the exception to this rule.
@@ -63,6 +64,7 @@ class LineFeeder(metaclass=ABCMeta):
 
         "Part" is the symbol_name, "partw" is the tag and args is:
         (<ListExpression: (<Integer: 10>,)>, <String: "abcde">)
+
         """
 
         if symbol_name == "Syntax":
@@ -74,7 +76,7 @@ class LineFeeder(metaclass=ABCMeta):
 
     def syntax_message(self, symbol_name: str, tag: str, *args) -> list:
         """
-        Append a syntax-message error message to the message queue.
+        Append a "Syntax" error message to the message queue.
         """
 
         if len(args) > 3:

--- a/mathics_scanner/prescanner.py
+++ b/mathics_scanner/prescanner.py
@@ -98,6 +98,7 @@ class Prescanner(object):
                     self.feeder.message("Syntax", "sntoct2")
                 elif last == 3:
                     self.feeder.message("Syntax", "sntoct1")
+                    raise ScanError()
                 elif last == 4:
                     self.feeder.message("Syntax", "snthex")
                 else:
@@ -151,6 +152,16 @@ class Prescanner(object):
             # Stay in same line fragment, but advance the cursor position.
             self.pos = i + 1
 
+        # FIXME:
+        #  The following code is boneheadedly wrong because
+        #  the surrounding lexical context determines whether
+        #  an escape sequences should be valid or not.
+        #  For example, inside a comment, there is no such thing
+        #  as an invalid escape sequence. And this cause  \050 which is
+        #  a valid escape sequence, parenthesis, to get treated like
+        #  a grouping symbol inside of a string.
+        # ...
+        #
         # In the following loop, we look for and replace escape
         # sequences. The current character under consideration is at
         # self.code[self.pos].  When an escape sequence is found at

--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -574,6 +574,13 @@ class Tokeniser:
                     # We have a \ at the end of a line.
                     self.incomplete()
                     skipped_chars.append(self.pos)
+
+                # Code below is in pre-scanner. We might decide
+                # later to move that code here.
+                # elif self.code[self.pos + 1] in "01234567":
+                #     # See if we have an octal number.
+                #     try_parse_base(1, 4, 8)
+
                 else:
                     # newlines (\n), tabs (\t) and double backslash
                     # "\\" have the backslash preserved. But for other
@@ -591,7 +598,7 @@ class Tokeniser:
                         self.feeder.message(
                             "Syntax", "stresc", self.code[self.pos : self.pos + 2]
                         )
-                        return Token("String", "", start)
+                        raise ScanError()
 
                     self.pos += 2
             else:

--- a/test/test_string_tokens.py
+++ b/test/test_string_tokens.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+Tests translation from text characters to the token: String
+"""
+
+import pytest
+
+from mathics_scanner.errors import IncompleteSyntaxError
+from mathics_scanner.feed import SingleLineFeeder
+from mathics_scanner.tokeniser import Token, Tokeniser
+
+
+def check_string(source_text, expected_text: str):
+    token = single_token(source_text)
+    assert token is not None
+    assert token.tag == "String"
+    assert token.text == expected_text
+
+
+def incomplete_error(s: str):
+    with pytest.raises(IncompleteSyntaxError):
+        get_tokens(s)
+
+
+def single_token(source_text) -> Token:
+    tokens = get_tokens(source_text)
+    assert len(tokens) == 1
+    token = tokens[0]
+    return token
+
+
+def get_tokens(source_text: str):
+    tokeniser = Tokeniser(SingleLineFeeder(source_text))
+    tokens = []
+    while True:
+        token = tokeniser.next()
+        if token.tag == "END":
+            break
+        else:
+            tokens.append(token)
+    return tokens
+
+
+def test_string():
+    for ctrl_char in ("\b", "\f", "\n", "\r", "\t"):
+        check_string(f'"a{ctrl_char}"', f'"a{ctrl_char}"')
+
+    incomplete_error(r'"a\X"')
+    check_string(r'"abc"', r'"abc"')
+    incomplete_error(r'"abc')
+    check_string(r'"abc(*def*)"', r'"abc(*def*)"')
+    check_string(r'"a\"b\\c"', r'"a\"b\\c"')
+    incomplete_error(r'"\"')

--- a/test/test_string_tokens.py
+++ b/test/test_string_tokens.py
@@ -51,8 +51,8 @@ def get_tokens(source_text: str):
 
 
 def test_string():
-    for ctrl_char in ("\b", "\f", "\n", "\r", "\t"):
-        check_string(f'"a{ctrl_char}"', f'"a{ctrl_char}"')
+    for escape_string in ("\b", "\f", "\n", "\r", "\t"):
+        check_string(f'"a{escape_string}"', f'"a{escape_string}"')
 
     # Broken:
     # "a\050", "a\051" "a\052"
@@ -64,4 +64,4 @@ def test_string():
     check_string(r'"a\"b\\c"', r'"a\"b\\c"')
     incomplete_error(r'"abc', "String does not have terminating quote")
     incomplete_error(r'"\"', "Unterminated escape sequence")
-    incomplete_error(r'"a\X"', '"X" is not a valid escape character')
+    scan_error(r'"a\X"', '"X" is not a valid escape character')

--- a/test/test_tokeniser.py
+++ b/test/test_tokeniser.py
@@ -3,13 +3,14 @@
 Tests translation from strings to sequences of tokens.
 """
 
-import pytest
 import random
 import sys
 
-from mathics_scanner.tokeniser import Tokeniser, Token, is_symbol_name
-from mathics_scanner.errors import ScanError, IncompleteSyntaxError, InvalidSyntaxError
+import pytest
+
+from mathics_scanner.errors import IncompleteSyntaxError, InvalidSyntaxError, ScanError
 from mathics_scanner.feed import SingleLineFeeder
+from mathics_scanner.tokeniser import Token, Tokeniser, is_symbol_name
 
 
 def check_number(code):
@@ -20,11 +21,6 @@ def check_number(code):
 def check_symbol(code):
     token = single_token(code)
     assert token, Token("Symbol", code, 0)
-
-
-def check_string(code):
-    token = single_token(code)
-    assert token, Token("String", code, 0)
 
 
 def incomplete_error(string):
@@ -184,12 +180,15 @@ def test_precision():
     check_number("1.5`10")
 
 
-def test_string():
-    check_string(r'"abc"')
-    incomplete_error(r'"abc')
-    check_string(r'"abc(*def*)"')
-    check_string(r'"a\"b\\c"')
-    incomplete_error(r'"\"')
+# String tests (with many more than those
+# below are now in test_string_token.py
+#
+# def test_string():
+#     check_string(r'"abc"')
+#     incomplete_error(r'"abc')
+#     check_string(r'"abc(*def*)"')
+#     check_string(r'"a\"b\\c"')
+#     incomplete_error(r'"\"')
 
 
 def test_set():


### PR DESCRIPTION
Handle backslash better...
    
Recognize special escape characters \n, \t, \r, etc., but disallow other characters.

feed.py: lint and fix types
    
test/test_string_tokens.py: Split out string token test from other test_tokeniser.py which is getting large. Add more string token tests.
