### PR TITLE
More amslatex

### DIFF
--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -761,7 +761,7 @@ CapitalChi:
   wl-unicode-name: GREEK CAPITAL LETTER CHI
 
 CapitalDHacek:
-  amslatex: "\\v{D}"
+  amslatex: '\v{D}'
   esc-alias: Dv
   has-unicode-inverse: false
   is-letter-like: true
@@ -773,7 +773,7 @@ CapitalDHacek:
   wl-unicode-name: LATIN CAPITAL LETTER D WITH CARON
 
 CapitalDelta:
-  amslatex: "\\Delta"
+  amslatex: '\Delta'
   esc-alias: D
   has-unicode-inverse: true
   is-letter-like: true
@@ -831,7 +831,7 @@ CapitalEBar:
   wl-unicode-name: LATIN CAPITAL LETTER E WITH MACRON
 
 CapitalECup:
-  amslatex: "\\u{E}"
+  amslatex: '\u{E}'
   esc-alias: Eu
   has-unicode-inverse: false
   is-letter-like: true
@@ -864,7 +864,7 @@ CapitalEGrave:
   wl-unicode-name: LATIN CAPITAL LETTER E WITH GRAVE
 
 CapitalEHacek:
-  amslatex: "\\v{E}"
+  amslatex: '\v{E}'
   esc-alias: Ev
   has-unicode-inverse: false
   is-letter-like: true
@@ -918,7 +918,7 @@ CapitalEth:
   wl-unicode-name: LATIN CAPITAL LETTER ETH
 
 CapitalGamma:
-  amslatex: "\\Gamma"
+  amslatex: '\Gamma'
   esc-alias: G
   has-unicode-inverse: false
   is-letter-like: true
@@ -941,7 +941,7 @@ CapitalIAcute:
   wl-unicode-name: LATIN CAPITAL LETTER I WITH ACUTE
 
 CapitalICup:
-  amslatex: "\\u{I}"
+  amslatex: '\u{I}'
   esc-alias: Iu
   has-unicode-inverse: false
   is-letter-like: true
@@ -1017,7 +1017,7 @@ CapitalKoppa:
   wl-unicode-name: GREEK LETTER KOPPA
 
 CapitalLSlash:
-  amslatex: "\\L{}"
+  amslatex: '\L{}'
   esc-alias: L/
   has-unicode-inverse: false
   is-letter-like: true
@@ -1029,7 +1029,7 @@ CapitalLSlash:
   wl-unicode-name: LATIN CAPITAL LETTER L WITH STROKE
 
 CapitalLambda:
-  amslatex: "\\Lambda"
+  amslatex: '\Lambda'
   esc-alias: L
   has-unicode-inverse: false
   is-letter-like: true
@@ -1052,7 +1052,7 @@ CapitalMu:
   wl-unicode-name: GREEK CAPITAL LETTER MU
 
 CapitalNHacek:
-  amslatex: "\\v{N}"
+  amslatex: '\v{N}'
   esc-alias: Nv
   has-unicode-inverse: false
   is-letter-like: true
@@ -1150,7 +1150,7 @@ CapitalOHat:
   wl-unicode-name: LATIN CAPITAL LETTER O WITH CIRCUMFLEX
 
 CapitalOSlash:
-  amslatex: "\\O{}"
+  amslatex: '\O{}'
   esc-alias: O/
   has-unicode-inverse: true
   is-letter-like: true
@@ -1171,7 +1171,7 @@ CapitalOTilde:
   wl-unicode-name: LATIN CAPITAL LETTER O WITH TILDE
 
 CapitalOmega:
-  amslatex: "\\Omega"
+  amslatex: '\Omega'
   esc-alias: O
   has-unicode-inverse: false
   is-letter-like: true
@@ -1194,7 +1194,7 @@ CapitalOmicron:
   wl-unicode-name: GREEK CAPITAL LETTER OMICRON
 
 CapitalPhi:
-  amslatex: "\\Phi"
+  amslatex: '\Phi'
   esc-alias: Ph
   has-unicode-inverse: false
   is-letter-like: true
@@ -1218,7 +1218,7 @@ CapitalPi:
   wl-unicode-name: GREEK CAPITAL LETTER PI
 
 CapitalPsi:
-  amslatex: "\\Psi"
+  amslatex: '\Psi'
   esc-alias: Ps
   has-unicode-inverse: false
   is-letter-like: true
@@ -1230,7 +1230,7 @@ CapitalPsi:
   wl-unicode-name: GREEK CAPITAL LETTER PSI
 
 CapitalRHacek:
-  amslatex: "\\v{R}"
+  amslatex: '\v{R}'
   esc-alias: Rv
   has-unicode-inverse: false
   is-letter-like: true
@@ -1253,7 +1253,7 @@ CapitalRho:
   wl-unicode-name: GREEK CAPITAL LETTER RHO
 
 CapitalSHacek:
-  amslatex: "\\v{S}"
+  amslatex: '\v{S}'
   esc-alias: Sv
   has-unicode-inverse: false
   is-letter-like: true
@@ -1276,7 +1276,7 @@ CapitalSampi:
   wl-unicode-name: GREEK LETTER SAMPI
 
 CapitalSigma:
-  amslatex: "\\Sigma"
+  amslatex: '\Sigma'
   esc-alias: S
   has-unicode-inverse: false
   is-letter-like: true
@@ -1299,7 +1299,7 @@ CapitalStigma:
   wl-unicode-name: GREEK LETTER STIGMA
 
 CapitalTHacek:
-  amslatex: "\\v{T}"
+  amslatex: '\v{T}'
   esc-alias: Tv
   has-unicode-inverse: false
   is-letter-like: true
@@ -1322,7 +1322,7 @@ CapitalTau:
   wl-unicode-name: GREEK CAPITAL LETTER TAU
 
 CapitalTheta:
-  amslatex: "\\Theta"
+  amslatex: '\Theta'
   esc-alias: Th
   has-unicode-inverse: false
   is-letter-like: true
@@ -1408,7 +1408,7 @@ CapitalURing:
   wl-unicode-name: LATIN CAPITAL LETTER U WITH RING ABOVE
 
 CapitalUpsilon:
-  amslatex: "\\Upsilon"
+  amslatex: '\Upsilon'
   esc-alias: U
   has-unicode-inverse: false
   is-letter-like: true
@@ -1420,7 +1420,7 @@ CapitalUpsilon:
   wl-unicode-name: GREEK CAPITAL LETTER UPSILON
 
 CapitalXi:
-  amslatex: "\\Xi"
+  amslatex: '\Xi'
   esc-alias: X
   has-unicode-inverse: false
   is-letter-like: true
@@ -1443,7 +1443,7 @@ CapitalYAcute:
   wl-unicode-name: LATIN CAPITAL LETTER Y WITH ACUTE
 
 CapitalZHacek:
-  amslatex: "\\v{Z}"
+  amslatex: '\v{Z}'
   esc-alias: Zv
   has-unicode-inverse: false
   is-letter-like: true
@@ -1539,7 +1539,7 @@ Checkmark:
   wl-unicode-name: CHECK MARK
 
 Chi:
-  amslatex: "\\chi"
+  amslatex: '\chi'
   esc-alias: ch
   has-unicode-inverse: false
   is-letter-like: true
@@ -1551,7 +1551,7 @@ Chi:
   wl-unicode-name: GREEK SMALL LETTER CHI
 
 CircleDot:
-  amslatex: "\\odot"
+  amslatex: '\odot'
   esc-alias: c.
   has-unicode-inverse: false
   is-letter-like: false
@@ -1564,7 +1564,7 @@ CircleDot:
   wl-unicode-name: CIRCLED DOT OPERATOR
 
 CircleMinus:
-  amslatex: "\\ominus"
+  amslatex: '\ominus'
   esc-alias: c-
   has-unicode-inverse: false
   is-letter-like: false
@@ -1590,7 +1590,7 @@ CirclePlus:
   wl-unicode-name: CIRCLED PLUS
 
 CircleTimes:
-  amslatex: "\\otimes"
+  amslatex: '\otimes'
   esc-alias: c*
   has-unicode-inverse: false
   is-letter-like: false
@@ -1755,7 +1755,7 @@ Continuation:
   wl-unicode: "\uF3B1"
 
 ContourIntegral:
-  amslatex: "\\oint"
+  amslatex: '\oint'
   esc-alias: cint
   has-unicode-inverse: false
   is-letter-like: false
@@ -1775,7 +1775,7 @@ ControlKey:
   wl-unicode: "\uF763"
 
 Coproduct:
-  amslatex: "\\coprod"
+  amslatex: '\coprod'
   esc-alias: coprod
   has-unicode-inverse: false
   is-letter-like: false
@@ -1819,7 +1819,7 @@ Cross:
   wl-unicode: "\uF4A0"
 
 Cup:
-  amslatex: "\\cup"
+  amslatex: '\cup'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Cup
@@ -1929,7 +1929,7 @@ Currency:
   wl-unicode-name: CURRENCY SIGN
 
 DHacek:
-  amslatex: "\\v{d}"
+  amslatex: '\v{d}'
   esc-alias: dv
   has-unicode-inverse: false
   is-letter-like: true
@@ -1940,7 +1940,7 @@ DHacek:
   wl-unicode-name: LATIN SMALL LETTER D WITH CARON
 
 Dagger:
-  amslatex: "\\dagger"
+  amslatex: '\dagger'
   esc-alias: dg
   has-unicode-inverse: false
   is-letter-like: false
@@ -1951,7 +1951,7 @@ Dagger:
   wl-unicode-name: DAGGER
 
 Dalet:
-  amslatex: "\\daleth"
+  amslatex: '\daleth'
   esc-alias: da
   has-unicode-inverse: false
   is-letter-like: false
@@ -2007,7 +2007,7 @@ Degree:
   wl-unicode-name: DEGREE SIGN
 
 Del:
-  amslatex: "\\nabla"
+  amslatex: '\nabla'
   esc-alias: del
   has-unicode-inverse: false
   is-letter-like: false
@@ -2027,7 +2027,7 @@ DeleteKey:
   wl-unicode: "\uF7D0"
 
 Delta:
-  amslatex: "\\delta"
+  amslatex: '\delta'
   esc-alias: d
   has-unicode-inverse: false
   is-letter-like: false
@@ -2132,7 +2132,7 @@ Digamma:
 # When there is a tag over the edge, WL uses a bold variant
 # of the symbol.
 DirectedEdge:
-  amslatex: "\\rightarrow"
+  amslatex: '\rightarrow'
   esc-alias: de
   has-unicode-inverse: false
   is-letter-like: false
@@ -2282,7 +2282,7 @@ DottedSquare:
   wl-unicode: "\uF751"
 
 DoubleContourIntegral:
-  amslatex: "\\oiint"
+  amslatex: '\oiint'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DoubleContourIntegral
@@ -2294,7 +2294,7 @@ DoubleContourIntegral:
   wl-unicode-name: SURFACE INTEGRAL
 
 DoubleDagger:
-  amslatex: "\\ddagger"
+  amslatex: '\ddagger'
   esc-alias: ddg
   has-unicode-inverse: false
   is-letter-like: false
@@ -2315,7 +2315,7 @@ DoubleDot:
   wl-unicode-name: DIAERESIS
 
 DoubleDownArrow:
-  amslatex: "\\Downarrow"
+  amslatex: '\Downarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DoubleDownArrow
@@ -2327,7 +2327,7 @@ DoubleDownArrow:
   wl-unicode-name: DOWNWARDS DOUBLE ARROW
 
 DoubleLeftArrow:
-  amslatex: "\\Leftarrow"
+  amslatex: '\Leftarrow'
   esc-alias: ' <='
   has-unicode-inverse: false
   is-letter-like: false
@@ -2340,7 +2340,7 @@ DoubleLeftArrow:
   wl-unicode-name: LEFTWARDS DOUBLE ARROW
 
 DoubleLeftRightArrow:
-  amslatex: "\\Leftrightarrow"
+  amslatex: '\Leftrightarrow'
   esc-alias: <=>
   has-unicode-inverse: false
   is-letter-like: false
@@ -2415,7 +2415,7 @@ DoublePrime:
   wl-unicode-name: DOUBLE PRIME
 
 DoubleRightArrow:
-  amslatex: "\\Rightarrow"
+  amslatex: '\Rightarrow'
   esc-alias: ' =>'
   has-unicode-inverse: false
   is-letter-like: false
@@ -3060,7 +3060,7 @@ DoubleStruckZero:
   wl-unicode: "\uF7DB"
 
 DoubleUpArrow:
-  amslatex: "\\Uparrow"
+  amslatex: '\Uparrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DoubleUpArrow
@@ -3072,7 +3072,7 @@ DoubleUpArrow:
   wl-unicode-name: UPWARDS DOUBLE ARROW
 
 DoubleUpDownArrow:
-  amslatex: "\\Updownarrow"
+  amslatex: '\Updownarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DoubleUpDownArrow
@@ -3084,7 +3084,7 @@ DoubleUpDownArrow:
   wl-unicode-name: UP DOWN DOUBLE ARROW
 
 DoubleVerticalBar:
-  amslatex: "\\parallel"
+  amslatex: '\parallel'
   esc-alias: ' ||'
   has-unicode-inverse: false
   is-letter-like: false
@@ -3097,7 +3097,7 @@ DoubleVerticalBar:
   wl-unicode-name: PARALLEL TO
 
 DoubledGamma:
-  amslatex: "\\mathbb{\\gamma}"
+  amslatex: '\mathbb{\gamma}'
   esc-alias: gg
   has-unicode-inverse: true
   is-letter-like: true
@@ -3119,7 +3119,7 @@ DoubledPi:
   wl-unicode: "\uF749"
 
 DownArrow:
-  amslatex: "\\downarrow"
+  amslatex: '\downarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownArrow
@@ -3326,7 +3326,7 @@ EBar:
   wl-unicode-name: LATIN SMALL LETTER E WITH MACRON
 
 ECup:
-  amslatex: "\\u{e}"
+  amslatex: '\u{e}'
   esc-alias: eu
   has-unicode-inverse: false
   is-letter-like: true
@@ -3360,7 +3360,7 @@ EGrave:
   wl-unicode-name: LATIN SMALL LETTER E WITH GRAVE
 
 EHacek:
-  amslatex: "\\v{e}"
+  amslatex: '\v{e}'
   esc-alias: ev
   has-unicode-inverse: false
   is-letter-like: true
@@ -3468,7 +3468,7 @@ EmptyRectangle:
   wl-unicode-name: WHITE VERTICAL RECTANGLE
 
 EmptySet:
-  amslatex: "\\varnothing"
+  amslatex: '\varnothing'
   esc-alias: es
   has-unicode-inverse: false
   is-letter-like: false
@@ -3628,7 +3628,7 @@ EscapeKey:
   wl-unicode: "\uF769"
 
 Eta:
-  amslatex: "\\eta"
+  amslatex: '\eta'
   esc-alias: et
   has-unicode-inverse: false
   is-letter-like: false
@@ -3659,7 +3659,7 @@ Euro:
   wl-unicode-name: EURO SIGN
 
 Exists:
-  amslatex: "\\exists"
+  amslatex: '\exists'
   esc-alias: ex
   has-unicode-inverse: false
   is-letter-like: false
@@ -3672,7 +3672,7 @@ Exists:
   wl-unicode-name: THERE EXISTS
 
 # ExpectationE:
-# #  amslatex: "\\ExpectationE"
+# #  amslatex: '\ExpectationE'
 # #  esc-alias: ee
 # #  has-unicode-inverse: true
 # #  is-letter-like: true
@@ -3683,7 +3683,7 @@ Exists:
 #   wl-unicode: "\uF2D3"
 
 ExponentialE:
-  amslatex: "\\ExponentialE"
+  amslatex: '\ExponentialE'
   esc-alias: ee
   has-unicode-inverse: true
   is-builtin-constant: true
@@ -4972,7 +4972,7 @@ FreakedSmiley:
 # unicode for each has to be different. Here we add
 # "LONG".
 Function:
-  amslatex: "\\mathsto"
+  amslatex: '\mathsto'
   ascii: "|->"
   has-unicode-inverse: false
   is-letter-like: false
@@ -5019,7 +5019,7 @@ Get:
   operator-name: Get
 
 Gimel:
-  amslatex: "\\gimel"
+  amslatex: '\gimel'
   esc-alias: gi
   has-unicode-inverse: false
   is-letter-like: false
@@ -5081,7 +5081,7 @@ GothicCapitalB:
   wl-unicode: "\uF78B"
 
 GothicCapitalC:
-  amslatex: "\\mathfrak{C}"
+  amslatex: '\mathfrak{C}'
   esc-alias: goC
   has-unicode-inverse: false
   is-letter-like: true
@@ -5735,7 +5735,7 @@ GreaterTilde:
   wl-unicode-name: GREATER-THAN OR EQUIVALENT TO
 
 HBar:
-  amslatex: "\\hbar"
+  amslatex: '\hbar'
   esc-alias: hb
   has-unicode-inverse: false
   is-letter-like: true
@@ -5847,7 +5847,7 @@ IAcute:
   wl-unicode-name: LATIN SMALL LETTER I WITH ACUTE
 
 ICup:
-  amslatex: "\\u{i}"
+  amslatex: '\u{i}'
   esc-alias: iu
   has-unicode-inverse: false
   is-letter-like: true
@@ -5892,7 +5892,7 @@ IHat:
   wl-unicode-name: LATIN SMALL LETTER I WITH CIRCUMFLEX
 
 ImaginaryI:
-  amslatex: "\\ComplexI"
+  amslatex: '\ComplexI'
   esc-alias: ii
   has-unicode-inverse: true
   is-builtin-constant: true
@@ -5904,7 +5904,7 @@ ImaginaryI:
   wl-unicode: "\uF74E"
 
 ImaginaryJ:
-  amslatex: "\\ComplexJ"
+  amslatex: '\ComplexJ'
   esc-alias: jj
   has-unicode-inverse: true
   is-builtin-constant: true
@@ -5926,7 +5926,7 @@ ImplicitPlus:
   wl-unicode: "\uF39E"
 
 Implies:
-  amslatex: "\\Rightarrow"
+  amslatex: '\Rightarrow'
   esc-alias: =>
   has-unicode-inverse: true
   is-letter-like: false
@@ -5945,7 +5945,7 @@ IndentingNewLine:
   wl-unicode: "\uF3A3"
 
 Infinity:
-  amslatex: "\\infty"
+  amslatex: '\infty'
   esc-alias: inf
   has-unicode-inverse: false
   is-builtin-constant: true
@@ -5961,7 +5961,7 @@ Infinity:
 # See also RawTilde
 Infix:
   ascii: "~"
-  amslatex: "\\textasciitilde"
+  amslatex: '\textasciitilde'
   has-unicode-inverse: false
   is-letter-like: false
 
@@ -5972,7 +5972,7 @@ Information:
   operator-name: Information
 
 Integral:
-  amslatex: "\\int"
+  amslatex: '\int'
   esc-alias: int
   has-unicode-inverse: false
   is-letter-like: false
@@ -5985,7 +5985,7 @@ Integral:
   wl-unicode-name: INTEGRAL
 
 InterpretedBox:
-  ascii: "\\!"
+  ascii: '\!'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: InterpretedBox
@@ -6058,7 +6058,7 @@ InvisibleTimes:
   wl-unicode-name: INVISIBLE TIMES
 
 Iota:
-  amslatex: "\\iota"
+  amslatex: '\iota'
   esc-alias: i
   has-unicode-inverse: false
   is-letter-like: false
@@ -6079,7 +6079,7 @@ Jupiter:
   wl-unicode-name: JUPITER
 
 Kappa:
-  amslatex: "\\kappa"
+  amslatex: '\kappa'
   esc-alias: k
   has-unicode-inverse: false
   is-letter-like: false
@@ -6106,7 +6106,7 @@ Koppa:
   wl-unicode-name: GREEK SMALL LETTER KOPPA
 
 LSlash:
-  amslatex: "\\l{}"
+  amslatex: '\l{}'
   esc-alias: l/
   has-unicode-inverse: false
   is-letter-like: true
@@ -6117,7 +6117,7 @@ LSlash:
   wl-unicode-name: LATIN SMALL LETTER L WITH STROKE
 
 Lambda:
-  amslatex: "\\lambda"
+  amslatex: '\lambda'
   esc-alias: l
   has-unicode-inverse: false
   is-letter-like: false
@@ -6145,7 +6145,7 @@ LeftAngleBracket:
   wl-unicode-name: LEFT-POINTING ANGLE BRACKET
 
 LeftArrow:
-  amslatex: "\\leftarrow"
+  amslatex: '\leftarrow'
   esc-alias: <-
   has-unicode-inverse: false
   is-letter-like: false
@@ -6170,7 +6170,7 @@ LeftArrowBar:
   wl-unicode-name: LEFTWARDS ARROW TO BAR
 
 LeftArrowRightArrow:
-  amslatex: "\\leftrightarrows"
+  amslatex: '\leftrightarrows'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftArrowRightArrow
@@ -6317,7 +6317,7 @@ LeftPointer:
   wl-unicode-name: BLACK LEFT-POINTING SMALL TRIANGLE
 
 LeftRightArrow:
-  amslatex: "\\leftrightarrow"
+  amslatex: '\leftrightarrow'
   esc-alias: <->
   has-unicode-inverse: false
   is-letter-like: false
@@ -6363,7 +6363,7 @@ LeftTee:
   wl-unicode-name: LEFT TACK
 
 LeftTeeArrow:
-  amslatex: "\\mapsfrom"
+  amslatex: '\mapsfrom'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftTeeArrow
@@ -6387,7 +6387,7 @@ LeftTeeVector:
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB UP FROM BAR
 
 LeftTriangle:
-  amslatex: "\\triangleleft"
+  amslatex: '\triangleleft'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftTriangle
@@ -6447,7 +6447,7 @@ LeftUpTeeVector:
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFT FROM BAR
 
 LeftUpVector:
-  amslatex: "\\upharpoonleft"
+  amslatex: '\upharpoonleft'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftUpVector
@@ -6681,7 +6681,7 @@ LongRightArrow:
   wl-unicode-name: LONG RIGHTWARDS ARROW
 
 LowerLeftArrow:
-  amslatex: "\\swarrow"
+  amslatex: '\swarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LowerLeftArrow
@@ -6693,7 +6693,7 @@ LowerLeftArrow:
   wl-unicode-name: SOUTH WEST ARROW
 
 LowerRightArrow:
-  amslatex: "\\searrow"
+  amslatex: '\searrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LowerRightArrow
@@ -6747,7 +6747,7 @@ MathematicaIcon:
   wl-unicode: "\uF757"
 
 MeasuredAngle:
-  amslatex: "\\measuredangle"
+  amslatex: '\measuredangle'
   has-unicode-inverse: false
   is-letter-like: false
   unicode-equivalent: "\u2221"
@@ -6844,7 +6844,7 @@ Mu:
   wl-unicode-name: GREEK SMALL LETTER MU
 
 NHacek:
-  amslatex: "\\v{n}"
+  amslatex: '\v{n}'
   esc-alias: nv
   has-unicode-inverse: false
   is-letter-like: true
@@ -7050,7 +7050,7 @@ NotDoubleVerticalBar:
   wl-unicode-name: NOT PARALLEL TO
 
 NotElement:
-  amslatex: "\\notin"
+  amslatex: '\notin'
   esc-alias: '!el'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7582,7 +7582,7 @@ NotVerticalBar:
   wl-unicode: "\uF3D1"
 
 Nu:
-  amslatex: "\\nu"
+  amslatex: '\nu'
   esc-alias: n
   has-unicode-inverse: false
   is-letter-like: false
@@ -7692,7 +7692,7 @@ OTilde:
   wl-unicode-name: LATIN SMALL LETTER O WITH TILDE
 
 Omega:
-  amslatex: "\\omega"
+  amslatex: '\omega'
   esc-alias: o
   has-unicode-inverse: false
   is-letter-like: false
@@ -7803,7 +7803,7 @@ Paragraph:
 # https://en.wikipedia.org/wiki/%E2%88%82 seems
 # to agree here.
 PartialD:
-  amslatex: "\\partial"
+  amslatex: '\partial'
   esc-alias: pd
   has-unicode-inverse: false
   is-letter-like: false
@@ -7944,6 +7944,7 @@ PreIncrement:
   operator-name: PreIncrement
 
 Precedes:
+  amslatex: '\prec'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Precedes
@@ -7955,6 +7956,7 @@ Precedes:
   wl-unicode-name: PRECEDES
 
 PrecedesEqual:
+  amslatex: '\preceq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: PrecedesEqual
@@ -7966,6 +7968,7 @@ PrecedesEqual:
   wl-unicode-name: PRECEDES ABOVE SINGLE-LINE EQUALS SIGN
 
 PrecedesSlantEqual:
+  amslatex: '\preccurlyeq' # WMA reports \precurlyeq, typo?
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: PrecedesSlantEqual
@@ -7977,6 +7980,7 @@ PrecedesSlantEqual:
   wl-unicode-name: PRECEDES OR EQUAL TO
 
 PrecedesTilde:
+  amslatex: '\precsim'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: PrecedesTilde
@@ -8019,6 +8023,7 @@ Product:
   wl-unicode-name: N-ARY PRODUCT
 
 Proportion:
+  ascii: '::'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: Proportion
@@ -8397,6 +8402,7 @@ ReverseElement:
   wl-unicode-name: CONTAINS AS MEMBER
 
 ReverseEquilibrium:
+  amslatex: '\leftrightharpoons'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: ReverseEquilibrium
@@ -8419,6 +8425,7 @@ ReversePrime:
   wl-unicode-name: REVERSED PRIME
 
 ReverseUpEquilibrium:
+  amslatex: '\downharpoonleft\upharpoonright' # in wma, \downharpoon\upharpoon
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: ReverseUpEquilibrium
@@ -8477,6 +8484,7 @@ RightArrow:
   wl-unicode-name: RIGHTWARDS ARROW
 
 RightArrowBar:
+  amslatex: '\rightarrow |'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightArrowBar
@@ -8488,7 +8496,7 @@ RightArrowBar:
   wl-unicode-name: RIGHTWARDS ARROW TO BAR
 
 RightArrowLeftArrow:
-  amslatex: "\\rightleftarrows"
+  amslatex: '\rightleftarrows'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightArrowLeftArrow
@@ -8562,6 +8570,7 @@ RightDoubleBracketingBar:
   wl-unicode: "\uF606"
 
 RightDownTeeVector:
+  amslatex: '\bar{\downharpoonright}' # WMA \bar{doenharpoonright}, maybe a typo.
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightDownTeeVector
@@ -8573,6 +8582,7 @@ RightDownTeeVector:
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB RIGHT FROM BAR
 
 RightDownVector:
+  amslatex: '\underline{\downharpoonright}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightDownVector
@@ -8648,6 +8658,7 @@ RightSkeleton:
   wl-unicode: "\uF762"
 
 RightTee:
+  amslatex: '\vdash'
   esc-alias: rT
   has-unicode-inverse: false
   operator-name: RightTee
@@ -8672,6 +8683,7 @@ RightTeeArrow:
   wl-unicode-name: RIGHTWARDS ARROW FROM BAR
 
 RightTeeVector:
+  amslatex: '|\rightharpoonup'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightTeeVector
@@ -8683,7 +8695,7 @@ RightTeeVector:
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB UP FROM BAR
 
 RightTriangle:
-  amslatex: "\\triangleright"
+  amslatex: '\triangleright'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightTriangle
@@ -8695,6 +8707,7 @@ RightTriangle:
   wl-unicode-name: CONTAINS AS NORMAL SUBGROUP
 
 RightTriangleBar:
+  amslatex: '|\triangleright'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightTriangleBar
@@ -8706,6 +8719,7 @@ RightTriangleBar:
   wl-unicode-name: VERTICAL BAR BESIDE RIGHT TRIANGLE
 
 RightTriangleEqual:
+  amslatex: '\trianglerighteq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightTriangleEqual
@@ -8717,6 +8731,7 @@ RightTriangleEqual:
   wl-unicode-name: CONTAINS AS NORMAL SUBGROUP OR EQUAL TO
 
 RightUpDownVector:
+  amslatex: '\stackrel{\upharpoonright}{\downharpoonright}' 
   has-unicode-inverse: false
   operator-name: RightUpDownVector
   is-letter-like: false
@@ -8728,6 +8743,7 @@ RightUpDownVector:
   wl-unicode-name: UP BARB RIGHT DOWN BARB RIGHT HARPOON
 
 RightUpTeeVector:
+  amslatex: '\underline{\upharpoonright}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightUpTeeVector
@@ -8739,7 +8755,7 @@ RightUpTeeVector:
   wl-unicode-name: UPWARDS HARPOON WITH BARB RIGHT FROM BAR
 
 RightUpVector:
-  amslatex: "\\upharpoonright"
+  amslatex: '\upharpoonright'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightUpVector
@@ -8751,6 +8767,7 @@ RightUpVector:
   wl-unicode-name: UPWARDS HARPOON WITH BARB RIGHTWARDS
 
 RightUpVectorBar:
+  amslatex: '\bar{\upharpoonright}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightUpVectorBar
@@ -8762,6 +8779,7 @@ RightUpVectorBar:
   wl-unicode-name: UPWARDS HARPOON WITH BARB RIGHT TO BAR
 
 RightVector:
+  amslatex: '\rightharpoonup'
   esc-alias: vec
   has-unicode-inverse: false
   is-letter-like: false
@@ -8774,6 +8792,7 @@ RightVector:
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB UPWARDS
 
 RightVectorBar:
+  amslatex: '\rightharpoonup |'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RightVectorBar
@@ -8786,6 +8805,7 @@ RightVectorBar:
 
 # Note: not the same as \[Superset]
 RoundImplies:
+  amslatex: '\text{RoundImplies}[a,b]'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: RoundImplies
@@ -8947,7 +8967,7 @@ ScriptCapitalA:
   wl-unicode: "\uF770"
 
 ScriptCapitalB:
-  amslatex: "\\mathcal{B}"
+  amslatex: '\mathcal{B}'
   esc-alias: scB
   has-unicode-inverse: false
   is-letter-like: true
@@ -8979,7 +8999,7 @@ ScriptCapitalD:
   wl-unicode: "\uF773"
 
 ScriptCapitalE:
-  amslatex: "\\mathcal{E}"
+  amslatex: '\mathcal{E}'
   esc-alias: scE
   has-unicode-inverse: false
   is-letter-like: true
@@ -8991,7 +9011,7 @@ ScriptCapitalE:
   wl-unicode-name: SCRIPT CAPITAL E
 
 ScriptCapitalF:
-  amslatex: "\\mathcal{F}"
+  amslatex: '\mathcal{F}'
   esc-alias: scF
   has-unicode-inverse: false
   is-letter-like: true
@@ -9066,7 +9086,7 @@ ScriptCapitalL:
   wl-unicode-name: SCRIPT CAPITAL L
 
 ScriptCapitalM:
-  amslatex: "\\mathcal{M}"
+  amslatex: '\mathcal{M}'
   esc-alias: scM
   has-unicode-inverse: false
   is-letter-like: true
@@ -9237,7 +9257,7 @@ ScriptDotlessJ:
   wl-unicode: "\uF731"
 
 ScriptE:
-  amslatex: "\\mathcal{e}"
+  amslatex:  '\mathcal{e}'
   esc-alias: sce
   has-unicode-inverse: false
   is-letter-like: true
@@ -9369,7 +9389,7 @@ ScriptNine:
   wl-unicode: "\uF7F9"
 
 ScriptO:
-  amslatex: "\\mathcal{o}"
+  amslatex: '\mathcal{o}'
   esc-alias: sco
   has-unicode-inverse: false
   is-letter-like: true
@@ -9601,7 +9621,7 @@ ShortRightArrow:
   wl-unicode: "\uF525"
 
 ShortUpArrow:
-  amslatex: "\\uparrow"
+  amslatex: '\uparrow'
   has-unicode-inverse: true
   is-letter-like: false
   unicode-equivalent: "\u2191"
@@ -9611,7 +9631,7 @@ ShortUpArrow:
   wl-unicode: "\uF52A"
 
 Sigma:
-  amslatex: "\\sigma"
+  amslatex: '\sigma'
   esc-alias: s
   has-unicode-inverse: false
   is-letter-like: false
@@ -9720,7 +9740,7 @@ SpanFromLeft:
   wl-unicode: "\uF3BA"
 
 SphericalAngle:
-  amslatex: "\\sphericalangle"
+  amslatex: '\sphericalangle'
   has-unicode-inverse: false
   is-letter-like: false
   unicode-equivalent: "\u2222"
@@ -9731,7 +9751,7 @@ SphericalAngle:
   wl-unicode-name: SPHERICAL ANGLE
 
 Sqrt:
-  amslatex: "\\sqrt"
+  amslatex: '\sqrt'
   esc-alias: sqrt
   has-unicode-inverse: false
   is-letter-like: false
@@ -9756,6 +9776,7 @@ Square:
   wl-unicode: "\uF520"
 
 SquareIntersection:
+  amslatex: '\sqcap'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SquareIntersection
@@ -9767,7 +9788,7 @@ SquareIntersection:
   wl-unicode-name: SQUARE CAP
 
 SquareSubset:
-  amslatex: "\\sqsubset"
+  amslatex: '\sqsubset'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SquareSubset
@@ -9779,7 +9800,7 @@ SquareSubset:
   wl-unicode-name: SQUARE IMAGE OF
 
 SquareSubsetEqual:
-  amslatex: "\\sqsubseteq"
+  amslatex: '\sqsubseteq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SquareSubsetEqual
@@ -9791,7 +9812,7 @@ SquareSubsetEqual:
   wl-unicode-name: SQUARE IMAGE OF OR EQUAL TO
 
 SquareSuperset:
-  amslatex: "\\sqsupset"
+  amslatex: '\sqsupset'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SquareSuperset
@@ -9803,7 +9824,7 @@ SquareSuperset:
   wl-unicode-name: SQUARE ORIGINAL OF
 
 SquareSupersetEqual:
-  amslatex: "\\sqsupseteq"
+  amslatex: '\sqsupseteq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SquareSupersetEqual
@@ -9815,6 +9836,7 @@ SquareSupersetEqual:
   wl-unicode-name: SQUARE ORIGINAL OF OR EQUAL TO
 
 SquareUnion:
+  amslatex: '\sqcup'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SquareUnion
@@ -9870,7 +9892,7 @@ StringJoin:
   operator-name: StringJoin
 
 Subset:
-  amslatex: "\\subset"
+  amslatex: '\subset'
   esc-alias: sub
   has-unicode-inverse: false
   is-letter-like: false
@@ -9883,7 +9905,7 @@ Subset:
   wl-unicode-name: SUBSET OF
 
 SubsetEqual:
-  amslatex: "\\subseteq"
+  amslatex: '\subseteq'
   esc-alias: sub=
   has-unicode-inverse: false
   is-letter-like: false
@@ -9902,6 +9924,7 @@ SubtractFrom:
   operator-name: SubtractFrom
 
 Succeeds:
+  amslatex: '\succ'
   has-unicode-inverse: false
   is-letter-like: false
   unicode-equivalent: "\u227B"
@@ -9913,6 +9936,7 @@ Succeeds:
   wl-unicode-name: SUCCEEDS
 
 SucceedsEqual:
+  amslatex: '\succeq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SucceedsEqual
@@ -9924,6 +9948,7 @@ SucceedsEqual:
   wl-unicode-name: SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN
 
 SucceedsSlantEqual:
+  amslatex: '\succeq'       # In WMA `$\succurlyeq`
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SucceedsSlantEqual
@@ -9935,6 +9960,7 @@ SucceedsSlantEqual:
   wl-unicode-name: SUCCEEDS OR EQUAL TO
 
 SucceedsTilde:
+  amslatex: '\succsim'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: SucceedsTilde
@@ -9946,6 +9972,7 @@ SucceedsTilde:
   wl-unicode-name: SUCCEEDS OR EQUIVALENT TO
 
 SuchThat:
+  amslatex: '\backepsilon'
   esc-alias: st
   has-unicode-inverse: false
   is-letter-like: false
@@ -9958,7 +9985,7 @@ SuchThat:
   wl-unicode-name: SMALL CONTAINS AS MEMBER
 
 Sum:
-  amslatex: "\\sum"
+  amslatex: '\sum'
   esc-alias: sum
   has-unicode-inverse: false
   is-letter-like: false
@@ -9971,6 +9998,7 @@ Sum:
   wl-unicode-name: N-ARY SUMMATION
 
 Superset:
+  amslatex: '\supset'
   esc-alias: sup
   has-unicode-inverse: false
   is-letter-like: false
@@ -9983,6 +10011,7 @@ Superset:
   wl-unicode-name: SUPERSET OF
 
 SupersetEqual:
+  amslatex: '\supseteq'
   esc-alias: sup=
   has-unicode-inverse: false
   is-letter-like: false
@@ -10007,7 +10036,7 @@ SystemsModelDelay:
   wl-unicode: "\uF3AF"
 
 THacek:
-  amslatex: "\\v{t}"
+  amslatex: '\v{t}'
   esc-alias: tv
   has-unicode-inverse: false
   is-letter-like: true
@@ -10031,7 +10060,7 @@ TagSet:
   operator-name: TagSet
 
 Tau:
-  amslatex: "\\tau"
+  amslatex: '\tau'
   esc-alias: t
   has-unicode-inverse: false
   is-letter-like: false
@@ -10067,6 +10096,7 @@ TensorWedge:
   wl-unicode: "\uF3DB"
 
 Therefore:
+  amslatex: '\therefore'
   esc-alias: tf
   has-unicode-inverse: false
   is-letter-like: false
@@ -10079,7 +10109,7 @@ Therefore:
   wl-unicode-name: THEREFORE
 
 Theta:
-  amslatex: "\\theta"
+  amslatex: '\theta'
   esc-alias: th
   has-unicode-inverse: false
   is-letter-like: false
@@ -10121,6 +10151,7 @@ Thorn:
 # so it is not the same as RawTilde.
 # Yes, it is confusing.
 Tilde:
+  amslatex: '\sim'
   esc-alias: '~'
   has-unicode-inverse: false
   is-letter-like: false
@@ -10146,6 +10177,7 @@ TildeEqual:
   wl-unicode-name: ASYMPTOTICALLY EQUAL TO
 
 TildeFullEqual:
+  amslatex: '\cong'
   esc-alias: ~==
   has-unicode-inverse: false
   is-letter-like: false
@@ -10158,6 +10190,7 @@ TildeFullEqual:
   wl-unicode-name: APPROXIMATELY EQUAL TO
 
 TildeTilde:
+  amslatex: '\approx'
   esc-alias: ~~
   has-unicode-inverse: false
   is-letter-like: false
@@ -10170,7 +10203,7 @@ TildeTilde:
   wl-unicode-name: ALMOST EQUAL TO
 
 Times:
-  amslatex: "\\times"
+  amslatex: '\times'
   ascii: '*'
   esc-alias: '*'
   has-unicode-inverse: false
@@ -10334,6 +10367,7 @@ UnsameQ:
   operator-name: UnsameQ
 
 Union:
+  amslatex: '\cup'
   esc-alias: un
   has-unicode-inverse: false
   is-letter-like: false
@@ -10346,6 +10380,7 @@ Union:
   wl-unicode-name: N-ARY UNION
 
 UnionPlus:
+  amslatex: '\uplus'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UnionPlus
@@ -10363,7 +10398,7 @@ Unset:
   operator-name: Unset
 
 UpArrow:
-  amslatex: "\\uparrow"
+  amslatex: '\uparrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UpArrow
@@ -10375,6 +10410,7 @@ UpArrow:
   wl-unicode-name: UPWARDS ARROW
 
 UpArrowBar:
+  amslatex: '\bar{\uparrow}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UpArrowBar
@@ -10386,7 +10422,7 @@ UpArrowBar:
   wl-unicode-name: UPWARDS ARROW TO BAR
 
 UpArrowDownArrow:
-  amslatex: "\\updownarrow"
+  amslatex: '\updownarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UpArrowDownArrow
@@ -10398,7 +10434,7 @@ UpArrowDownArrow:
   wl-unicode-name: UPWARDS ARROW LEFTWARDS OF DOWNWARDS ARROW
 
 UpDownArrow:
-  amslatex: "\\updownarrow"
+  amslatex: '\updownarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UpDownArrow
@@ -10410,6 +10446,7 @@ UpDownArrow:
   wl-unicode-name: UP DOWN ARROW
 
 UpEquilibrium:
+  amslatex: '\upharpoonleft \downharpoonright'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: UpEquilibrium
@@ -10431,6 +10468,7 @@ UpPointer:
   wl-unicode-name: BLACK UP-POINTING SMALL TRIANGLE
 
 UpTee:
+  amslatex: '\bot'
   esc-alias: uT
   has-unicode-inverse: false
   is-letter-like: false
@@ -10479,7 +10517,7 @@ UpperRightArrow:
   wl-unicode-name: NORTH EAST ARROW
 
 Upsilon:
-  amslatex: "\\upsilon"
+  amslatex: '\upsilon'
   esc-alias: u
   has-unicode-inverse: false
   is-letter-like: false
@@ -10582,6 +10620,7 @@ VerticalSeparator:
   wl-unicode: "\uF432"
 
 VerticalTilde:
+  amslatex: '\wr'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: VerticalTilde
@@ -10629,7 +10668,7 @@ WatchIcon:
   wl-unicode-name: WATCH
 
 Wedge:
-  amslatex: "\\wedge"
+  amslatex: '\wedge'
   esc-alias: ^
   has-unicode-inverse: false
   is-letter-like: false
@@ -10735,7 +10774,7 @@ WolframLanguageLogoCircle:
   wl-unicode: "\uF11F"
 
 Xi:
-  amslatex: "\\xi"
+  amslatex: '\xi'
   esc-alias: x
   has-unicode-inverse: false
   is-letter-like: false

--- a/mathics_scanner/data/named-characters.yml
+++ b/mathics_scanner/data/named-characters.yml
@@ -3131,6 +3131,7 @@ DownArrow:
   wl-unicode-name: DOWNWARDS ARROW
 
 DownArrowBar:
+  amslatex: '\underline{\downarrow}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownArrowBar
@@ -3142,6 +3143,7 @@ DownArrowBar:
   wl-unicode-name: DOWNWARDS ARROW TO BAR
 
 DownArrowUpArrow:
+  amslatex: '\downarrow \uparrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownArrowUpArrow
@@ -3172,6 +3174,7 @@ DownExclamation:
   wl-unicode-name: INVERTED EXCLAMATION MARK
 
 DownLeftRightVector:
+  amslatex: '\leftharpoondown \rightharpoondown'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownLeftRightVector
@@ -3183,6 +3186,7 @@ DownLeftRightVector:
   wl-unicode-name: LEFT BARB DOWN RIGHT BARB DOWN HARPOON
 
 DownLeftTeeVector:
+  amslatex: '\leftharpoondown |'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownLeftTeeVector
@@ -3194,7 +3198,7 @@ DownLeftTeeVector:
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB DOWN FROM BAR
 
 DownLeftVector:
-  amslatex: "\\leftharpoondown"
+  amslatex: '\leftharpoondown'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownLeftVector
@@ -3206,6 +3210,7 @@ DownLeftVector:
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB DOWNWARDS
 
 DownLeftVectorBar:
+  amslatex: '|\leftharpoondown'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownLeftVectorBar
@@ -3237,6 +3242,7 @@ DownQuestion:
   wl-unicode-name: INVERTED QUESTION MARK
 
 DownRightTeeVector:
+  amslatex: '|\rightharpoondown'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownRightTeeVector
@@ -3248,6 +3254,7 @@ DownRightTeeVector:
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB DOWN FROM BAR
 
 DownRightVector:
+  amslatex: '\rightharpoondown'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownRightVector
@@ -3259,6 +3266,7 @@ DownRightVector:
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB DOWNWARDS
 
 DownRightVectorBar:
+  amslatex: '\rightharpoondown |'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: DownRightVectorBar
@@ -3270,6 +3278,7 @@ DownRightVectorBar:
   wl-unicode-name: RIGHTWARDS HARPOON WITH BARB DOWN TO BAR
 
 DownTee:
+  amslatex: '\top'
   esc-alias: dT
   has-unicode-inverse: false
   is-letter-like: false
@@ -3567,6 +3576,7 @@ Equal:
   wl-unicode: "\uF431"
 
 EqualTilde:
+  amslatex: '\eqsim'
   esc-alias: =~
   has-unicode-inverse: false
   is-letter-like: false
@@ -3579,6 +3589,7 @@ EqualTilde:
   wl-unicode-name: MINUS TILDE
 
 Equilibrium:
+  amslatex: '\rightleftharpoons'
   esc-alias: equi
   has-unicode-inverse: false
   is-letter-like: false
@@ -3591,6 +3602,7 @@ Equilibrium:
   wl-unicode-name: RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON
 
 Equivalent:
+#  amslatex: '\unicode{29e6}'
   esc-alias: equiv
   has-unicode-inverse: true
   is-letter-like: false
@@ -5649,6 +5661,7 @@ GreaterEqual:
   wl-unicode-name: GREATER-THAN OR EQUAL TO
 
 GreaterEqualLess:
+  amslatex: 'a\gtreqless b'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: GreaterEqualLess
@@ -5660,6 +5673,7 @@ GreaterEqualLess:
   wl-unicode-name: GREATER-THAN EQUAL TO OR LESS-THAN
 
 GreaterFullEqual:
+  amslatex: '\geqq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: GreaterFullEqual
@@ -5671,6 +5685,7 @@ GreaterFullEqual:
   wl-unicode-name: GREATER-THAN OVER EQUAL TO
 
 GreaterGreater:
+  amslatex: '\gg'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: GreaterGreater
@@ -5682,6 +5697,7 @@ GreaterGreater:
   wl-unicode-name: MUCH GREATER-THAN
 
 GreaterLess:
+  amslatex: '\gtrless'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: GreaterLess
@@ -5693,6 +5709,7 @@ GreaterLess:
   wl-unicode-name: GREATER-THAN OR LESS-THAN
 
 GreaterSlantEqual:
+  amslatex: '\geq'
   esc-alias: '>/'
   has-unicode-inverse: false
   operator-name: GreaterSlantEqual
@@ -5705,6 +5722,7 @@ GreaterSlantEqual:
   wl-unicode-name: GREATER-THAN OR SLANTED EQUAL TO
 
 GreaterTilde:
+  amslatex: '\gtrsim' # In WMA, '\gtrsin' which seems a typo... 
   esc-alias: '>~'
   has-unicode-inverse: false
   operator-name: GreaterTilde
@@ -5781,6 +5799,7 @@ HorizontalLine:
   wl-unicode-name: BOX DRAWINGS LIGHT HORIZONTAL
 
 HumpDownHump:
+  amslatex: '\Bumpeq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: HumpDownHump
@@ -5792,6 +5811,7 @@ HumpDownHump:
   wl-unicode-name: GEOMETRICALLY EQUIVALENT TO
 
 HumpEqual:
+  amslatex: '\bumpeq'
   esc-alias: h=
   has-unicode-inverse: false
   is-letter-like: false
@@ -6138,6 +6158,7 @@ LeftArrow:
   wl-unicode-name: LEFTWARDS ARROW
 
 LeftArrowBar:
+  amslatex: '|\leftarrow'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftArrowBar
@@ -6215,6 +6236,7 @@ LeftDoubleBracketingBar:
   wl-unicode: "\uF605"
 
 LeftDownTeeVector:
+  amslatex: '\bar{\downharpoonleft}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftDownTeeVector
@@ -6226,6 +6248,7 @@ LeftDownTeeVector:
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB LEFT FROM BAR
 
 LeftDownVector:
+  amslatex: '\downharpoonleft'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftDownVector
@@ -6237,6 +6260,7 @@ LeftDownVector:
   wl-unicode-name: DOWNWARDS HARPOON WITH BARB LEFTWARDS
 
 LeftDownVectorBar:
+  amslatex: '\underline{\downharpoonleft}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftDownVectorBar
@@ -6306,6 +6330,7 @@ LeftRightArrow:
   wl-unicode-name: LEFT RIGHT ARROW
 
 LeftRightVector:
+  amslatex: '\leftharpoonup \rightharpoonup'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftRightVector
@@ -6325,6 +6350,7 @@ LeftSkeleton:
   wl-unicode: "\uF761"
 
 LeftTee:
+  amslatex: '\dashv'
   esc-alias: lT
   has-unicode-inverse: false
   is-letter-like: false
@@ -6349,6 +6375,7 @@ LeftTeeArrow:
   wl-unicode-name: LEFTWARDS ARROW FROM BAR
 
 LeftTeeVector:
+  amslatex: '\leftharpoonup |'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftTeeVector
@@ -6372,6 +6399,7 @@ LeftTriangle:
   wl-unicode-name: NORMAL SUBGROUP OF
 
 LeftTriangleBar:
+  amslatex: '\triangleleft |'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftTriangleBar
@@ -6383,6 +6411,7 @@ LeftTriangleBar:
   wl-unicode-name: LEFT TRIANGLE BESIDE VERTICAL BAR
 
 LeftTriangleEqual:
+  amslatex: '\trianglelefteq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftTriangleEqual
@@ -6394,6 +6423,7 @@ LeftTriangleEqual:
   wl-unicode-name: NORMAL SUBGROUP OF OR EQUAL TO
 
 LeftUpDownVector:
+  amslatex: '\stackrel{\upharpoonleft}{\downharpoonleft}' # In WMA, \overset instead \stackrel
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftUpDownVector
@@ -6405,6 +6435,7 @@ LeftUpDownVector:
   wl-unicode-name: UP BARB LEFT DOWN BARB LEFT HARPOON
 
 LeftUpTeeVector:
+  amslatex: '\underline{\upharpoonleft}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftUpTeeVector
@@ -6428,6 +6459,7 @@ LeftUpVector:
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFTWARDS
 
 LeftUpVectorBar:
+  amslatex: '\bar{\upharpoonleft}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftUpVectorBar
@@ -6439,6 +6471,7 @@ LeftUpVectorBar:
   wl-unicode-name: UPWARDS HARPOON WITH BARB LEFT TO BAR
 
 LeftVector:
+  amslatex: '\leftharpoonup'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftVector
@@ -6450,6 +6483,7 @@ LeftVector:
   wl-unicode-name: LEFTWARDS HARPOON WITH BARB UPWARDS
 
 LeftVectorBar:
+  amslatex: '|\leftharpoonup'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LeftVectorBar
@@ -6491,6 +6525,7 @@ LessEqual:
   wl-unicode-name: LESS-THAN OR EQUAL TO
 
 LessEqualGreater:
+  amslatex: '\lesseqgtr'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LessEqualGreater
@@ -6502,6 +6537,7 @@ LessEqualGreater:
   wl-unicode-name: LESS-THAN EQUAL TO OR GREATER-THAN
 
 LessFullEqual:
+  amslatex: '\leqq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LessFullEqual
@@ -6513,6 +6549,7 @@ LessFullEqual:
   wl-unicode-name: LESS-THAN OVER EQUAL TO
 
 LessGreater:
+  amslatex: '\lessgtr'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LessGreater
@@ -6524,6 +6561,7 @@ LessGreater:
   wl-unicode-name: LESS-THAN OR GREATER-THAN
 
 LessLess:
+  amslatex: '\ll'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: LessLess
@@ -6535,6 +6573,7 @@ LessLess:
   wl-unicode-name: MUCH LESS-THAN
 
 LessSlantEqual:
+  amslatex: '\leq'
   esc-alias: </
   has-unicode-inverse: false
   operator-name: LessSlantEqual
@@ -6547,6 +6586,7 @@ LessSlantEqual:
   wl-unicode-name: LESS-THAN OR SLANTED EQUAL TO
 
 LessTilde:
+  amslatex: '\lesssim'
   esc-alias: <~
   has-unicode-inverse: false
   is-letter-like: false
@@ -6602,6 +6642,7 @@ LongEqual:
   wl-unicode: "\uF7D9"
 
 LongLeftArrow:
+  amslatex: '\longleftarrow'
   esc-alias: <--
   has-unicode-inverse: false
   is-letter-like: false
@@ -6614,6 +6655,7 @@ LongLeftArrow:
   wl-unicode-name: LONG LEFTWARDS ARROW
 
 LongLeftRightArrow:
+  amslatex: '\longleftrightarrow'
   esc-alias: <-->
   has-unicode-inverse: false
   is-letter-like: false
@@ -6626,6 +6668,7 @@ LongLeftRightArrow:
   wl-unicode-name: LONG LEFT RIGHT ARROW
 
 LongRightArrow:
+  amslatex: '\longrightarrow'
   esc-alias: -->
   has-unicode-inverse: false
   is-letter-like: false
@@ -6882,6 +6925,7 @@ Neptune:
   wl-unicode-name: NEPTUNE
 
 NestedGreaterGreater:
+  amslatex: '\gg'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NestedGreaterGreater
@@ -6893,6 +6937,7 @@ NestedGreaterGreater:
   wl-unicode-name: DOUBLE NESTED GREATER-THAN
 
 NestedLessLess:
+  amslatex: '\ll'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NestedLessLess
@@ -6967,6 +7012,7 @@ Not:
   wl-unicode-name: NOT SIGN
 
 NotCongruent:
+  amslatex: '\not{\equiv}'
   esc-alias: '!==='
   has-unicode-inverse: false
   is-letter-like: false
@@ -6979,6 +7025,7 @@ NotCongruent:
   wl-unicode-name: NOT IDENTICAL TO
 
 NotCupCap:
+  amslatex: '\not{\stackrel{\smile}{\frown}}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotCupCap
@@ -7050,6 +7097,7 @@ NotExists:
   wl-unicode-name: THERE DOES NOT EXIST
 
 NotGreater:
+  amslatex: '\ngtr'
   esc-alias: '!>'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7062,6 +7110,7 @@ NotGreater:
   wl-unicode-name: NOT GREATER-THAN
 
 NotGreaterEqual:
+  amslatex: '\ngeq'
   esc-alias: '!>='
   has-unicode-inverse: false
   is-letter-like: false
@@ -7074,6 +7123,7 @@ NotGreaterEqual:
   wl-unicode-name: NEITHER GREATER-THAN NOR EQUAL TO
 
 NotGreaterFullEqual:
+  amslatex: '\ngeqq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotGreaterFullEqual
@@ -7085,13 +7135,16 @@ NotGreaterFullEqual:
   wl-unicode-name: GREATER-THAN BUT NOT EQUAL TO
 
 NotGreaterGreater:
+  amslatex: '\not{\gg}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotGreaterGreater
+  unicode-equivalent: "\uF427"
   wl-reference: https://reference.wolfram.com/language/ref/character/NotGreaterGreater.html
   wl-unicode: "\uF427"
 
 NotGreaterLess:
+  amslatex: '\not{\gtrless}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotGreaterLess
@@ -7110,6 +7163,7 @@ NotGreaterSlantEqual:
   wl-unicode: "\uF429"
 
 NotGreaterTilde:
+  amslatex: '\not{\gtrsim}'
   esc-alias: '!>~'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7135,6 +7189,7 @@ NotHumpEqual:
   wl-unicode: "\uF401"
 
 NotLeftTriangle:
+  amslatex: '\ntriangleleft'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotLeftTriangle
@@ -7152,6 +7207,7 @@ NotLeftTriangleBar:
   wl-unicode: "\uF412"
 
 NotLeftTriangleEqual:
+  amslatex: '\ntrianglelefteq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotLeftTriangleEqual
@@ -7163,6 +7219,7 @@ NotLeftTriangleEqual:
   wl-unicode-name: NOT NORMAL SUBGROUP OF OR EQUAL TO
 
 NotLess:
+  amslatex: '\nless'
   esc-alias: '!<'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7175,6 +7232,7 @@ NotLess:
   wl-unicode-name: NOT LESS-THAN
 
 NotLessEqual:
+  amslatex: '\nleq'
   esc-alias: '!<='
   has-unicode-inverse: false
   is-letter-like: false
@@ -7187,6 +7245,7 @@ NotLessEqual:
   wl-unicode-name: NEITHER LESS-THAN NOR EQUAL TO
 
 NotLessFullEqual:
+  amslatex: '\nleqq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotLessFullEqual
@@ -7198,6 +7257,7 @@ NotLessFullEqual:
   wl-unicode-name: LESS-THAN BUT NOT EQUAL TO
 
 NotLessGreater:
+  amslatex: '\not{\lessgtr}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotLessGreater
@@ -7222,6 +7282,7 @@ NotLessSlantEqual:
   wl-unicode: "\uF424"
 
 NotLessTilde:
+  amslatex: '\not{\lesssim}'
   esc-alias: '!<~'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7246,6 +7307,7 @@ NotNestedLessLess:
   wl-unicode: "\uF423"
 
 NotPrecedes:
+  amslatex: '\nprec'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotPrecedes
@@ -7263,6 +7325,7 @@ NotPrecedesEqual:
   wl-unicode: "\uF42B"
 
 NotPrecedesSlantEqual:
+  amslatex: '\not{\preccurlyeq}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotPrecedesSlantEqual
@@ -7274,6 +7337,7 @@ NotPrecedesSlantEqual:
   wl-unicode-name: DOES NOT PRECEDE OR EQUAL
 
 NotPrecedesTilde:
+  amslatex: '\not{\precsim}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotPrecedesTilde
@@ -7298,6 +7362,7 @@ NotReverseElement:
   wl-unicode-name: DOES NOT CONTAIN AS MEMBER
 
 NotRightTriangle:
+  amslatex: '\ntriangleright'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotRightTriangle
@@ -7315,6 +7380,7 @@ NotRightTriangleBar:
   wl-unicode: "\uF413"
 
 NotRightTriangleEqual:
+  amslatex: '\ntrianglerighteq'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotRightTriangleEqual
@@ -7332,6 +7398,7 @@ NotSquareSubset:
   wl-unicode: "\uF42E"
 
 NotSquareSubsetEqual:
+  amslatex: '\not{\sqsubseteq}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotSquareSubsetEqual
@@ -7343,6 +7410,7 @@ NotSquareSubsetEqual:
   wl-unicode-name: NOT SQUARE IMAGE OF OR EQUAL TO
 
 NotSquareSuperset:
+  amslatex: '\not{\sqsupseteq}'
   has-unicode-inverse: false
   is-letter-like: false
   wl-reference: https://reference.wolfram.com/language/ref/character/NotSquareSuperset.html
@@ -7360,6 +7428,7 @@ NotSquareSupersetEqual:
   wl-unicode-name: NOT SQUARE ORIGINAL OF OR EQUAL TO
 
 NotSubset:
+  amslatex: '\not{\subset}'
   esc-alias: '!sub'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7372,6 +7441,7 @@ NotSubset:
   wl-unicode-name: NOT A SUBSET OF
 
 NotSubsetEqual:
+  amslatex: '\nsubseteq'
   esc-alias: '!sub='
   has-unicode-inverse: false
   is-letter-like: false
@@ -7384,6 +7454,7 @@ NotSubsetEqual:
   wl-unicode-name: NEITHER A SUBSET OF NOR EQUAL TO
 
 NotSucceeds:
+  amslatex: '\nsucc'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotSucceeds
@@ -7402,6 +7473,7 @@ NotSucceedsEqual:
   wl-unicode: "\uF42D"
 
 NotSucceedsSlantEqual:
+  amslatex: '\not{\succeq}'  # in WMA, \succurlyeq, typo?
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotSucceedsSlantEqual
@@ -7413,6 +7485,7 @@ NotSucceedsSlantEqual:
   wl-unicode-name: DOES NOT SUCCEED OR EQUAL
 
 NotSucceedsTilde:
+  amslatex: '\not{\succsim}'
   has-unicode-inverse: false
   is-letter-like: false
   operator-name: NotSucceedsTilde
@@ -7424,6 +7497,7 @@ NotSucceedsTilde:
   wl-unicode-name: SUCCEEDS BUT NOT EQUIVALENT TO
 
 NotSuperset:
+  amslatex: '\not{\supset}'
   esc-alias: '!sup'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7436,6 +7510,7 @@ NotSuperset:
   wl-unicode-name: NOT A SUPERSET OF
 
 NotSupersetEqual:
+  amslatex: '\nsupseteq'
   esc-alias: '!sup='
   has-unicode-inverse: false
   is-letter-like: false
@@ -7448,6 +7523,7 @@ NotSupersetEqual:
   wl-unicode-name: NEITHER A SUPERSET OF NOR EQUAL TO
 
 NotTilde:
+  amslatex: '\not{\sim}'
   esc-alias: '!~'
   has-unicode-inverse: false
   is-letter-like: false
@@ -7460,6 +7536,7 @@ NotTilde:
   wl-unicode-name: NOT TILDE
 
 NotTildeEqual:
+  amslatex: '\not{\simeq}'
   esc-alias: '!~='
   has-unicode-inverse: false
   is-letter-like: false
@@ -7472,6 +7549,7 @@ NotTildeEqual:
   wl-unicode-name: NOT ASYMPTOTICALLY EQUAL TO
 
 NotTildeFullEqual:
+  amslatex: '\ncong'
   esc-alias: '!~=='
   has-unicode-inverse: false
   is-letter-like: false
@@ -7484,6 +7562,7 @@ NotTildeFullEqual:
   wl-unicode-name: NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
 
 NotTildeTilde:
+  amslatex: '\not{\approx}'
   esc-alias: '!~~'
   has-unicode-inverse: false
   is-letter-like: false


### PR DESCRIPTION
This completes the amslatex field for all the operator-like symbols. Also replaces the use of double quotes with escape characters whenever it is possible.