### PR TITLE
Treat \ before newline as whitespace.

### DIFF
--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -741,6 +741,15 @@ class Tokeniser:
                 self.pos += 2
             elif self.source_text[self.pos] in " \r\n\t":
                 self.pos += 1
+            elif (
+                self.source_text[self.pos] == "\\"
+                and self.pos + 2 == len(self.source_text)
+                and self.source_text[self.pos + 1] == "\n"
+            ):
+                # We have a backslashed \n probably in order to split
+                # a long Mathics3 source-text line.  Treat this as
+                # whitespace.
+                self.pos += 2
             else:
                 break
 

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -9,9 +9,9 @@ from mathics_scanner.location import ContainerKind
 def test_multi():
     """Test MultiLineFeeder class"""
     feeder = MultiLineFeeder("abc\ndef", "<test_multi>", ContainerKind.STRING)
-    feeder.feed() == "abc\n", "MultiLineFeeder reads first line"
-    feeder.feed() == "def", "reads second line"
-    feeder.feed() == "", "Returns '' when no more lines"
+    assert feeder.feed() == "abc\n", "MultiLineFeeder reads first line"
+    assert feeder.feed() == "def", "reads second line"
+    assert feeder.feed() == "", "Returns '' when no more lines"
     assert feeder.empty(), "MultiLineFeeder detects feeder empty condition"
 
 


### PR DESCRIPTION
Note: this was seen in Rubi.m line 215. And also FeynCalc FCMain.m  line 362.