### PR TITLE
Run Mathic3 full tests using Python 3.13...

### DIFF
--- a/.github/workflows/mathics.yml
+++ b/.github/workflows/mathics.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Run tests using Python 3.13 is faster.