### PR TITLE
Escaped braces in String mode is ok.

### DIFF
--- a/mathics_scanner/tokeniser.py
+++ b/mathics_scanner/tokeniser.py
@@ -956,14 +956,19 @@ class Tokeniser:
                         result += "\\" + escaped_char
                         self.pos += 1
                     else:
-                        # Not something that can be a boxing construct.
-                        # So here, we'll report an error as we do with
-                        # NamedCharacterSyntaxError.
-                        self.feeder.message(
-                            escape_error.name, escape_error.tag, *escape_error.args
-                        )
-                        raise
-
+                        # Not something that can be a boxing
+                        # construct.  Some characters like "{", and
+                        # "}" are allowed to follow a "\" in the
+                        # String context, but any other character is
+                        # an error.
+                        if self.source_text[self.pos] in ["{", "}"]:
+                            result += "\\" + escaped_char
+                            self.pos += 1
+                        else:
+                            self.feeder.message(
+                                escape_error.name, escape_error.tag, *escape_error.args
+                            )
+                            raise
                 else:
                     result += escape_str
             else:

--- a/test/test_string_tokens.py
+++ b/test/test_string_tokens.py
@@ -86,6 +86,14 @@ def test_string():
     check_string(r'"\ abc"', '" abc"', "Escaped space in a string is valid")
     check_string(r'"abc(*def*)"', r'"abc(*def*)"')
 
+    # Example found in usage string for FCSetPauliSigmaScheme of
+    # FeynCalc.
+    check_string(
+        r'"$\{\\sigma^i, \\sigma^j \}$."',
+        r'"$\{\sigma^i, \sigma^j \}$."',
+        "Escaped braces inside a string are ok",
+    )
+
     check_string(
         r'"\(a \+\)"',
         r'"\(a \+\)"',


### PR DESCRIPTION
 Escaped braces in String mode is ok.

You can find an example of this in the usage string for FCSetPauliSigmaScheme of FeynCalc.


