### PR TITLE
Syntax message gives full line in "sntufn" tag

### DIFF
--- a/mathics_scanner/escape_sequences.py
+++ b/mathics_scanner/escape_sequences.py
@@ -63,7 +63,7 @@ def parse_named_character(source_text: str, start: int, finish: int) -> Optional
     if named_character.isalpha():
         char = named_characters.get(named_character)
         if char is None:
-            raise NamedCharacterSyntaxError("sntufn", named_character)
+            raise NamedCharacterSyntaxError("sntufn", named_character, source_text)
         else:
             return char
 

--- a/mathics_scanner/feed.py
+++ b/mathics_scanner/feed.py
@@ -107,7 +107,12 @@ class LineFeeder(metaclass=ABCMeta):
             else:
                 message.append('""')
         message.append(str(self.lineno))
-        message.append(f'"{self.container}"')
+        if self.container:
+            message.append(f'"{self.container}"')
+        elif len(args) == 2:
+            message.append(f'"{(args[1].rstrip())}"')
+        else:
+            message.append("")
         assert len(message) == 7
         return message
 

--- a/mathics_scanner/mathics3_tokens.py
+++ b/mathics_scanner/mathics3_tokens.py
@@ -176,7 +176,7 @@ def interactive_eval_loop(shell: TerminalShell, code_tokenize_format: bool):
             shell.errmsg(
                 "Syntax",
                 "sntufn",
-                "Unknown unicode longname",
+                "Unknown escape sequence",
             )
         # This has to come after NamedCharacterSyntaxError and
         # EscapeSyntaxError since those are subclasses of


### PR DESCRIPTION
On Syntax errors in an interactive shell, we were showing something weird for the container (name of file when a file is given). Store instead the entered input text.