### PR TITLE
Misc fixes noticed in mathics-core

### DIFF
--- a/mathics_scanner/data/operators.yml
+++ b/mathics_scanner/data/operators.yml
@@ -461,8 +461,7 @@ BlankSequenceHead:
   # comments:
 
 BoxGroup:
-  Precedence-Function: 670
-  precedence: 760
+  precedence: 670
   WolframLanguageData:
   WolframLanguageData-corrected: 1
   UnicodeCharacters.tr:

--- a/mathics_scanner/generate/build_operator_tables.py
+++ b/mathics_scanner/generate/build_operator_tables.py
@@ -152,7 +152,7 @@ def compile_tables(
         "no-meaning-prefix-operators": no_meaning_prefix_operators,
         "non-associative-binary-operators": nonassoc_binary_operators,
         "operator-to-amslatex": operator2amslatex,
-        "operator-to_string": operator2string,
+        "operator-to-string": operator2string,
         "operator-precedences": operator_precedences,
         "postfix-operators": postfix_operators,
         "prefix-operators": prefix_operators,


### PR DESCRIPTION
BoxGroup precedence is 670.
operator-to_string -> operator-to-string